### PR TITLE
Allow to use DateTimeInterface to create Aeon objects

### DIFF
--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -54,8 +54,9 @@ final class DateTime
 
     /**
      * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
      */
-    public static function fromDateTime(\DateTimeImmutable $dateTime) : self
+    public static function fromDateTime(\DateTimeInterface $dateTime) : self
     {
         return new self(
             Day::fromDateTime($dateTime),

--- a/src/Aeon/Calendar/Gregorian/Day.php
+++ b/src/Aeon/Calendar/Gregorian/Day.php
@@ -39,8 +39,9 @@ final class Day
 
     /**
      * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
      */
-    public static function fromDateTime(\DateTimeImmutable $dateTime) : self
+    public static function fromDateTime(\DateTimeInterface $dateTime) : self
     {
         return new self(
             new Month(

--- a/src/Aeon/Calendar/Gregorian/Month.php
+++ b/src/Aeon/Calendar/Gregorian/Month.php
@@ -40,8 +40,9 @@ final class Month
 
     /**
      * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
      */
-    public static function fromDateTime(\DateTimeImmutable $dateTime) : self
+    public static function fromDateTime(\DateTimeInterface $dateTime) : self
     {
         return new self(
             new Year((int) $dateTime->format('Y')),

--- a/src/Aeon/Calendar/Gregorian/Time.php
+++ b/src/Aeon/Calendar/Gregorian/Time.php
@@ -51,8 +51,9 @@ final class Time
 
     /**
      * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
      */
-    public static function fromDateTime(\DateTimeImmutable $dateTime) : self
+    public static function fromDateTime(\DateTimeInterface $dateTime) : self
     {
         return new self(
             (int) $dateTime->format('H'),

--- a/src/Aeon/Calendar/Gregorian/Year.php
+++ b/src/Aeon/Calendar/Gregorian/Year.php
@@ -31,8 +31,9 @@ final class Year
 
     /**
      * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
      */
-    public static function fromDateTime(\DateTimeImmutable $dateTime) : self
+    public static function fromDateTime(\DateTimeInterface $dateTime) : self
     {
         return new self((int) $dateTime->format('Y'));
     }


### PR DESCRIPTION
Unfortunately psalm detects `\DateTimeInterface::format` method as ImpureMethodCall 