### PR TITLE
Remove minimum stability dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "description": "PHP type safe, immutable calendar library",
     "keywords": ["calendar", "immutable", "holidays", "sleep"],
     "prefer-stable": true,
-    "minimum-stability": "dev",
     "require": {
         "php": ">=7.4.2",
         "webmozart/assert": "^1.8"


### PR DESCRIPTION
Since this repository does not depends on anything that did not have stable release yet I think it's fine to revert minimum-stability to stable