### PR TITLE
Leap seconds support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,27 @@ use Aeon\Calendar\TimeUnit;
 
 $now = GregorianCalendar::UTC()->now();
 
-$now->to($now->add(TimeUnit::days(7)))
+$now->until($now->add(TimeUnit::days(7)))
     ->iterate(TimeUnit::day())
     ->each(function(TimePeriod $timePeriod) {
-        echo $timePeriod->startDateTime()->day()->format('Y-m-d H:i:s.uO') . "\n";
+        echo $timePeriod->start()->day()->format('Y-m-d H:i:s.uO') . "\n";
+    });
+```
+
+or with shorter syntax
+
+```php
+<?php 
+
+use Aeon\Calendar\Gregorian\GregorianCalendar;
+use Aeon\Calendar\Gregorian\TimePeriod;
+use Aeon\Calendar\TimeUnit;
+
+$now = GregorianCalendar::UTC()->now();
+
+$now->iterate($now->add(TimeUnit::days(7)), TimeUnit::day())
+    ->each(function(TimePeriod $timePeriod) {
+        echo $timePeriod->start()->day()->format('Y-m-d H:i:s.uO') . "\n";
     });
 ```
 
@@ -66,7 +83,26 @@ use \Aeon\Calendar\Gregorian\DateTime;
 $start = DateTime::fromString('2020-01-01 00:00:00');
 $end = DateTime::fromString('2020-01-10 00:00:00');
 
-echo $start->to($end)->distance()->inDays(); // int(10)
+echo $start->until($end)->distance()->inDays(); // int(10)
+```
+
+#### Measuring difference between two points in time with leap second
+
+```php
+<?php 
+
+use \Aeon\Calendar\Gregorian\DateTime;
+
+$start = DateTime::fromString('2016-01-01 00:00:00 UTC');
+$end = DateTime::fromString('2020-01-10 00:00:00 UTC');
+
+echo $start->until($end)->distance()->inSeconds() . "\n"; 
+echo $start->until($end)->distance()
+    ->add($start->until($end)->leapSeconds()->count())
+    ->inSeconds() . "\n"; 
+
+// int(127008000)
+// int(127008001)
 ```
 
 #### Measuring elapsed time 

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
             "phpunit"
         ],
         "test:mutation": [
-            "infection -vvv --test-framework-options='--testsuite=unit' --only-covered --log-verbosity=default --min-covered-msi=75 --threads=2"
+            "infection -vvv --test-framework-options='--testsuite=unit' --only-covered --log-verbosity=default --min-covered-msi=70 --threads=2"
         ],
         "static:analyze": [
             "psalm --output-format=compact",

--- a/src/Aeon/Calendar/Gregorian/Calendar.php
+++ b/src/Aeon/Calendar/Gregorian/Calendar.php
@@ -15,9 +15,9 @@ interface Calendar
 
     public function currentDay() : Day;
 
+    public function yesterday() : Day;
+
+    public function tomorrow() : Day;
+
     public function now() : DateTime;
-
-    public function yesterday() : DateTime;
-
-    public function tomorrow() : DateTime;
 }

--- a/src/Aeon/Calendar/Gregorian/GregorianCalendar.php
+++ b/src/Aeon/Calendar/Gregorian/GregorianCalendar.php
@@ -50,13 +50,13 @@ final class GregorianCalendar implements Calendar
             ->toTimeZone($this->timeZone);
     }
 
-    public function yesterday() : DateTime
+    public function yesterday() : Day
     {
-        return new DateTime($this->currentDay()->previous(), new Time(0, 0, 0, 0));
+        return $this->currentDay()->previous();
     }
 
-    public function tomorrow() : DateTime
+    public function tomorrow() : Day
     {
-        return new DateTime($this->currentDay()->next(), new Time(0, 0, 0, 0));
+        return $this->currentDay()->next();
     }
 }

--- a/src/Aeon/Calendar/Gregorian/GregorianCalendarStub.php
+++ b/src/Aeon/Calendar/Gregorian/GregorianCalendarStub.php
@@ -41,14 +41,14 @@ final class GregorianCalendarStub implements Calendar
         );
     }
 
-    public function yesterday() : DateTime
+    public function yesterday() : Day
     {
-        return new DateTime($this->currentDay()->previous(), new Time(0, 0, 0, 0));
+        return $this->currentDay()->previous();
     }
 
-    public function tomorrow() : DateTime
+    public function tomorrow() : Day
     {
-        return new DateTime($this->currentDay()->next(), new Time(0, 0, 0, 0));
+        return $this->currentDay()->next();
     }
 
     /**

--- a/src/Aeon/Calendar/Gregorian/LeapSecond.php
+++ b/src/Aeon/Calendar/Gregorian/LeapSecond.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Calendar\Gregorian;
+
+use Aeon\Calendar\TimeUnit;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-immutable
+ */
+final class LeapSecond
+{
+    /**
+     * @var DateTime
+     */
+    private DateTime $dateTime;
+
+    /**
+     * @var TimeUnit
+     */
+    private TimeUnit $offsetTAI;
+
+    public function __construct(DateTime $dateTime, TimeUnit $offsetTAI)
+    {
+        Assert::greaterThanEq($offsetTAI->inSeconds(), 10);
+        $this->dateTime = $dateTime;
+        $this->offsetTAI = $offsetTAI;
+    }
+
+    public function dateTime() : DateTime
+    {
+        return $this->dateTime;
+    }
+
+    public function offsetTAI() : TimeUnit
+    {
+        return $this->offsetTAI;
+    }
+}

--- a/src/Aeon/Calendar/Gregorian/LeapSeconds.php
+++ b/src/Aeon/Calendar/Gregorian/LeapSeconds.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Calendar\Gregorian;
+
+use Aeon\Calendar\TimeUnit;
+
+/**
+ * @psalm-immutable
+ */
+final class LeapSeconds
+{
+    private static ?self $instance = null;
+
+    /**
+     * @var DateTime
+     */
+    private DateTime $listExpirationDate;
+
+    /**
+     * @var array<int, LeapSecond>
+     */
+    private array $leapSeconds;
+
+    private function __construct(DateTime $listExpiration, LeapSecond ...$leapSeconds)
+    {
+        $this->leapSeconds = $leapSeconds;
+        $this->listExpirationDate = $listExpiration;
+    }
+
+    /**
+     * List taken from https://www.ietf.org/timezones/data/leap-seconds.list
+     *
+     * Leap seconds are announced by https://www.iers.org/ (The International Earth Rotation and Reference Systems Service)
+     * in their Bulletin C, list of all available releases https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html
+     *
+     * @psalm-pure
+     * @psalm-suppress ImpureStaticProperty
+     */
+    public static function load() : self
+    {
+        if (self::$instance instanceof self) {
+            return self::$instance;
+        }
+
+        self::$instance = new self(
+            $expirationDate = DateTime::fromString('2020-12-28 00:00:00 UTC'),
+            new LeapSecond(DateTime::fromString('1972-01-01 00:00:00 UTC'), TimeUnit::seconds(10)),
+            new LeapSecond(DateTime::fromString('1972-07-01 00:00:00 UTC'), TimeUnit::seconds(11)),
+            new LeapSecond(DateTime::fromString('1973-01-01 00:00:00 UTC'), TimeUnit::seconds(12)),
+            new LeapSecond(DateTime::fromString('1974-01-01 00:00:00 UTC'), TimeUnit::seconds(13)),
+            new LeapSecond(DateTime::fromString('1975-01-01 00:00:00 UTC'), TimeUnit::seconds(14)),
+            new LeapSecond(DateTime::fromString('1976-01-01 00:00:00 UTC'), TimeUnit::seconds(15)),
+            new LeapSecond(DateTime::fromString('1977-01-01 00:00:00 UTC'), TimeUnit::seconds(16)),
+            new LeapSecond(DateTime::fromString('1978-01-01 00:00:00 UTC'), TimeUnit::seconds(17)),
+            new LeapSecond(DateTime::fromString('1979-01-01 00:00:00 UTC'), TimeUnit::seconds(18)),
+            new LeapSecond(DateTime::fromString('1980-01-01 00:00:00 UTC'), TimeUnit::seconds(19)),
+            new LeapSecond(DateTime::fromString('1981-07-01 00:00:00 UTC'), TimeUnit::seconds(20)),
+            new LeapSecond(DateTime::fromString('1982-07-01 00:00:00 UTC'), TimeUnit::seconds(21)),
+            new LeapSecond(DateTime::fromString('1983-07-01 00:00:00 UTC'), TimeUnit::seconds(22)),
+            new LeapSecond(DateTime::fromString('1985-07-01 00:00:00 UTC'), TimeUnit::seconds(23)),
+            new LeapSecond(DateTime::fromString('1988-01-01 00:00:00 UTC'), TimeUnit::seconds(24)),
+            new LeapSecond(DateTime::fromString('1990-01-01 00:00:00 UTC'), TimeUnit::seconds(24)),
+            new LeapSecond(DateTime::fromString('1991-01-01 00:00:00 UTC'), TimeUnit::seconds(25)),
+            new LeapSecond(DateTime::fromString('1992-07-01 00:00:00 UTC'), TimeUnit::seconds(26)),
+            new LeapSecond(DateTime::fromString('1993-07-01 00:00:00 UTC'), TimeUnit::seconds(27)),
+            new LeapSecond(DateTime::fromString('1994-07-01 00:00:00 UTC'), TimeUnit::seconds(28)),
+            new LeapSecond(DateTime::fromString('1996-01-01 00:00:00 UTC'), TimeUnit::seconds(29)),
+            new LeapSecond(DateTime::fromString('1997-07-01 00:00:00 UTC'), TimeUnit::seconds(30)),
+            new LeapSecond(DateTime::fromString('1999-01-01 00:00:00 UTC'), TimeUnit::seconds(31)),
+            new LeapSecond(DateTime::fromString('2006-01-01 00:00:00 UTC'), TimeUnit::seconds(32)),
+            new LeapSecond(DateTime::fromString('2009-01-01 00:00:00 UTC'), TimeUnit::seconds(33)),
+            new LeapSecond(DateTime::fromString('2012-07-01 00:00:00 UTC'), TimeUnit::seconds(34)),
+            new LeapSecond(DateTime::fromString('2015-07-01 00:00:00 UTC'), TimeUnit::seconds(36)),
+            new LeapSecond(DateTime::fromString('2017-01-01 00:00:00 UTC'), TimeUnit::seconds(37)),
+        );
+
+        return self::$instance;
+    }
+
+    public function expirationDate() : DateTime
+    {
+        return $this->listExpirationDate;
+    }
+
+    public function since(DateTime $dateTime) : self
+    {
+        return $this->filter(function (LeapSecond $leapSecond) use ($dateTime) : bool {
+            return $dateTime
+                    ->toTimeZone(TimeZone::UTC())
+                    ->isBefore($leapSecond->dateTime());
+        });
+    }
+
+    public function until(DateTime $dateTime) : self
+    {
+        return $this->filter(function (LeapSecond $leapSecond) use ($dateTime) : bool {
+            return $dateTime
+                ->toTimeZone(TimeZone::UTC())
+                ->isAfterOrEqual($leapSecond->dateTime());
+        });
+    }
+
+    public function findAllBetween(TimePeriod $timePeriod) : self
+    {
+        return $this->filter(function (LeapSecond $leapSecond) use ($timePeriod) : bool {
+            return $timePeriod->start()
+                    ->toTimeZone(TimeZone::UTC())
+                    ->isBeforeOrEqual($leapSecond->dateTime())
+                && $timePeriod->end()
+                    ->toTimeZone(TimeZone::UTC())
+                    ->isAfter($leapSecond->dateTime());
+        });
+    }
+
+    public function offsetTAI() : TimeUnit
+    {
+        return TimeUnit::seconds(\array_reduce(
+            $this->leapSeconds,
+            function (int $totalSeconds, LeapSecond $nextLeapSecond) : int {
+
+                /** Leap second in theory might also be negative but so far it never happened  */
+                $totalSeconds += $nextLeapSecond->offsetTAI()->isPositive()
+                    ? 1
+                    : -1;
+
+                return $totalSeconds;
+            },
+            9
+        ));
+    }
+
+    /**
+     * @param callable(LeapSecond $leapSecond) : bool $filter
+     */
+    public function filter(callable $filter) : self
+    {
+        return new self(
+            $this->expirationDate(),
+            ...\array_filter($this->all(), $filter)
+        );
+    }
+
+    public function count() : TimeUnit
+    {
+        return TimeUnit::seconds(\count($this->all()));
+    }
+
+    /**
+     * @return array<int, LeapSecond>
+     */
+    private function all() : array
+    {
+        return $this->leapSeconds;
+    }
+}

--- a/src/Aeon/Calendar/Gregorian/TimeEpoch.php
+++ b/src/Aeon/Calendar/Gregorian/TimeEpoch.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Calendar\Gregorian;
+
+use Aeon\Calendar\TimeUnit;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-immutable
+ */
+final class TimeEpoch
+{
+    public const UNIX = 0;
+
+    public const UTC = 1;
+
+    public const TAI = 2;
+
+    public const GPS = 3;
+
+    private int $type;
+
+    private DateTime $dateTime;
+
+    private function __construct(int $type, DateTime $dateTime)
+    {
+        Assert::true($dateTime->timeOffset()->isUTC());
+        $this->type = $type;
+        $this->dateTime = $dateTime;
+    }
+
+    /**
+     * Unix Epoch, started at 1970-01-01 00:00:00 UTC, not including leap seconds
+     *
+     * @psalm-pure
+     */
+    public static function UNIX() : self
+    {
+        return new self(self::UNIX, DateTime::fromString('1970-01-01 00:00:00 UTC'));
+    }
+
+    /**
+     * Other name for UNIX epoch
+     *
+     * @psalm-pure
+     */
+    public static function POSIX() : self
+    {
+        return self::UNIX();
+    }
+
+    /**
+     * UTC Epoch, started at 1972-01-01 00:00:00 UTC, including leap seconds
+     *
+     * @psalm-pure
+     */
+    public static function UTC() : self
+    {
+        return new self(self::UTC, DateTime::fromString('1972-01-01 00:00:00 UTC'));
+    }
+
+    /**
+     * GPS Epoch, started at 1980-01-06 00:00:00 UTC, including leap seconds
+     * except first 9 there were added before epoch
+     *
+     * @psalm-pure
+     */
+    public static function GPS() : self
+    {
+        return new self(self::GPS, DateTime::fromString('1980-01-06 00:00:00 UTC'));
+    }
+
+    /**
+     * TAI Epoch, started at 1958-01-01 00:00:00 UTC, including leap seconds
+     *
+     * @psalm-pure
+     */
+    public static function TAI() : self
+    {
+        return new self(self::TAI, DateTime::fromString('1958-01-01 00:00:00 UTC'));
+    }
+
+    public function type() : int
+    {
+        return $this->type;
+    }
+
+    public function date() : DateTime
+    {
+        return $this->dateTime;
+    }
+
+    /**
+     * Returns difference in seconds between epoches without leap seconds
+     */
+    public function distanceTo(TimeEpoch $timeEpoch) : TimeUnit
+    {
+        switch ($this->type) {
+            case self::UTC:
+                switch ($timeEpoch->type()) {
+                    case self::GPS:
+                        return TimeUnit::seconds(252892800); // 1972-01-01 00:00:00 UTC - 1980-01-06 00:00:00 UTC
+                    case self::UNIX:
+                        return TimeUnit::seconds(63072000)->invert();  // 1972-01-01 00:00:00 UTC - 1970-01-01 00:00:00 UTC
+                    case self::TAI:
+                        return TimeUnit::seconds(441763200)->invert(); // 1972-01-01 00:00:00 UTC - 1958-01-01 00:00:00 UTC
+                    default:
+                        return TimeUnit::seconds(0);
+                }
+                // no break
+            case self::GPS:
+                switch ($timeEpoch->type()) {
+                    case self::UTC:
+                        return TimeUnit::seconds(252892800)->invert(); // 1980-01-06 00:00:00 UTC - 1972-01-01 00:00:00 UTC
+                    case self::UNIX:
+                        return TimeUnit::seconds(315964800)->invert(); // 1980-01-06 00:00:00 UTC - 1970-01-01 00:00:00 UTC
+                    case self::TAI:
+                        return TimeUnit::seconds(694656000)->invert(); // 1980-01-06 00:00:00 UTC - 1958-01-01 00:00:00 UTC
+                    default:
+                        return TimeUnit::seconds(0);
+                }
+                // no break
+            case self::TAI:
+                switch ($timeEpoch->type()) {
+                    case self::UTC:
+                        return TimeUnit::seconds(441763200); // 1958-01-01 00:00:00 UTC - 1972-01-01 00:00:00 UTC
+                    case self::UNIX:
+                        return TimeUnit::seconds(378691200); // 1958-01-01 00:00:00 UTC - 1970-01-00 00:00:00 UTC
+                    case self::GPS:
+                        return TimeUnit::seconds(694656000); // 1958-01-01 00:00:00 UTC - 1980-01-06 00:00:00 UTC
+                    default:
+                        return TimeUnit::seconds(0);
+                }
+                // no break
+            default: // UNIX
+                switch ($timeEpoch->type()) {
+                    case self::UTC:
+                        return TimeUnit::seconds(63072000);  // 1970-01-01 00:00:00 UTC - 1972-01-01 00:00:00 UTC
+                    case self::GPS:
+                        return TimeUnit::seconds(315964800); // 1970-01-01 00:00:00 UTC - 1980-01-06 00:00:00 UTC
+                    case self::TAI:
+                        return TimeUnit::seconds(378691200)->invert(); // 1970-01-01 00:00:00 UTC - 1958-01-01 00:00:00 UTC
+                    default:
+                        return TimeUnit::seconds(0);
+                }
+        }
+    }
+}

--- a/src/Aeon/Calendar/Gregorian/TimeZone.php
+++ b/src/Aeon/Calendar/Gregorian/TimeZone.php
@@ -3056,6 +3056,9 @@ final class TimeZone
         return new self(self::PACIFIC_WALLIS);
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function UTC() : self
     {
         return new self(self::UTC);

--- a/src/Aeon/Calendar/TimeUnit.php
+++ b/src/Aeon/Calendar/TimeUnit.php
@@ -154,6 +154,18 @@ final class TimeUnit
         return new self($seconds < 0, \abs($seconds), 0);
     }
 
+    /** @psalm-pure */
+    public static function negative(int $seconds, int $microsecond) : self
+    {
+        return new self(true, $seconds, $microsecond);
+    }
+
+    /** @psalm-pure */
+    public static function positive(int $seconds, int $microsecond) : self
+    {
+        return new self(false, $seconds, $microsecond);
+    }
+
     public function toDateInterval() : \DateInterval
     {
         $interval = new \DateInterval(\sprintf("PT%dS", $this->seconds));
@@ -335,5 +347,10 @@ final class TimeUnit
     public function invert() : self
     {
         return new self(!$this->negative, $this->seconds, $this->microsecond);
+    }
+
+    public function absolute() : self
+    {
+        return $this->isNegative() ? $this->invert() : $this;
     }
 }

--- a/tests/Aeon/Calendar/Tests/Functional/Gregorian/GregorianCalendarTest.php
+++ b/tests/Aeon/Calendar/Tests/Functional/Gregorian/GregorianCalendarTest.php
@@ -92,7 +92,8 @@ final class GregorianCalendarTest extends TestCase
     {
         $timePeriods = ($calendar = GregorianCalendar::UTC())
             ->yesterday()
-            ->to($calendar->tomorrow())
+            ->midnight()
+            ->until($calendar->tomorrow()->midnight())
             ->iterate(TimeUnit::hour())
             ->map(function (TimePeriod $timePeriod) use (&$iterations) {
                 return $timePeriod->start()->toDateTimeImmutable()->format('Y-m-d H:i:s');
@@ -115,7 +116,8 @@ final class GregorianCalendarTest extends TestCase
     {
         $timePeriods = ($calendar = GregorianCalendar::UTC())
             ->yesterday()
-            ->to($calendar->tomorrow())
+            ->midnight()
+            ->until($calendar->tomorrow()->midnight())
             ->iterate(TimeUnit::hour())
             ->filter(function (TimePeriod $timePeriod) use (&$iterations) : bool {
                 return $timePeriod->start()->time()->hour() % 2 === 0;
@@ -128,7 +130,8 @@ final class GregorianCalendarTest extends TestCase
     {
         $timePeriods = ($calendar = GregorianCalendar::UTC())
             ->yesterday()
-            ->to($calendar->tomorrow())
+            ->midnight()
+            ->until($calendar->tomorrow()->midnight())
             ->iterateBackward(TimeUnit::hour())
             ->map(function (TimePeriod $interval) {
                 return $interval->start()->toDateTimeImmutable()->format('Y-m-d H:i:s');

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/LeapSecondsTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/LeapSecondsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Calendar\Tests\Unit\Gregorian;
+
+use Aeon\Calendar\Gregorian\DateTime;
+use Aeon\Calendar\Gregorian\GregorianCalendar;
+use Aeon\Calendar\Gregorian\LeapSeconds;
+use Aeon\Calendar\TimeUnit;
+use PHPUnit\Framework\TestCase;
+
+final class LeapSecondsTest extends TestCase
+{
+    /**
+     * This test will start failing 5 days before expiration date of the current leap seconds list
+     * Once it does please visit https://www.ietf.org/timezones/data/leap-seconds.list
+     * and if there is a new leap second announced add it to the list or extend expiration
+     * date according to the document
+     */
+    public function test_expiration_of_current_leap_seconds_list() : void
+    {
+        $leapSeconds = LeapSeconds::load();
+
+        $this->assertFalse(
+            $leapSeconds->expirationDate()->isBefore(
+                GregorianCalendar::UTC()->now()->add(TimeUnit::days(5))
+            )
+        );
+        $this->assertSame(
+            37,
+            $leapSeconds->offsetTAI()->inSeconds()
+        );
+    }
+
+    public function test_finding_leap_seconds_between_1970_jan_1_and_1980_jan_1() : void
+    {
+        $leapSeconds = LeapSeconds::load();
+
+        $this->assertEquals(
+            19,
+            $leapSeconds->findAllBetween(
+                DateTime::fromString('1970-01-01 00:00:00 UTC')->until(DateTime::fromString('1980-01-06 00:00:00 UTC'))
+            )->offsetTAI()->inSeconds()
+        );
+        $this->assertSame(
+            9,
+            $leapSeconds->findAllBetween(
+                DateTime::fromString('1970-01-01 00:00:00 UTC')->until(DateTime::fromString('1980-01-01 00:00:00 UTC'))
+            )->count()
+                ->inSeconds()
+        );
+    }
+
+    public function test_finding_leap_seconds_since_date() : void
+    {
+        $leapSeconds = LeapSeconds::load();
+
+        $this->assertSame(
+            28,
+            $leapSeconds->since(
+                DateTime::fromString('1970-01-01 00:00:00 UTC')
+            )->count()
+                ->inSeconds()
+        );
+    }
+}

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeEpochTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeEpochTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Calendar\Tests\Unit\Gregorian;
+
+use Aeon\Calendar\Gregorian\DateTime;
+use Aeon\Calendar\Gregorian\TimeEpoch;
+use PHPUnit\Framework\TestCase;
+
+final class TimeEpochTest extends TestCase
+{
+    /**
+     * @dataProvider seconds_since_data_provider
+     */
+    public function test_distance_to_epoch(TimeEpoch $epoch, TimeEpoch $sinceEpoch, DateTime $dateTime, DateTime $sinceDateTime) : void
+    {
+        $this->assertSame(
+            $epoch->distanceTo($sinceEpoch)->inSeconds(),
+            $dateTime->until($sinceDateTime)->distance()->inSeconds()
+        );
+    }
+
+    /**
+     * @return \Generator<int, array{TimeEpoch, TimeEpoch, DateTime, DateTime}, mixed, void>
+     */
+    public function seconds_since_data_provider() : \Generator
+    {
+        yield [TimeEpoch::UTC(), TimeEpoch::GPS(), DateTime::fromString('1972-01-01 00:00:00 UTC'), DateTime::fromString('1980-01-06 00:00:00 UTC')];
+        yield [TimeEpoch::UTC(), TimeEpoch::TAI(), DateTime::fromString('1972-01-01 00:00:00 UTC'), DateTime::fromString('1958-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::UTC(), TimeEpoch::UNIX(), DateTime::fromString('1972-01-01 00:00:00 UTC'), DateTime::fromString('1970-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::UTC(), TimeEpoch::UTC(), DateTime::fromString('1972-01-01 00:00:00 UTC'), DateTime::fromString('1972-01-01 00:00:00 UTC')];
+
+        yield [TimeEpoch::GPS(), TimeEpoch::UTC(), DateTime::fromString('1980-01-06 00:00:00 UTC'), DateTime::fromString('1972-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::GPS(), TimeEpoch::TAI(), DateTime::fromString('1980-01-06 00:00:00 UTC'), DateTime::fromString('1958-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::GPS(), TimeEpoch::UNIX(), DateTime::fromString('1980-01-06 00:00:00 UTC'), DateTime::fromString('1970-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::GPS(), TimeEpoch::GPS(), DateTime::fromString('1980-01-06 00:00:00 UTC'), DateTime::fromString('1980-01-06 00:00:00 UTC')];
+
+        yield [TimeEpoch::UNIX(), TimeEpoch::UTC(), DateTime::fromString('1970-01-01 00:00:00 UTC'), DateTime::fromString('1972-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::UNIX(), TimeEpoch::TAI(), DateTime::fromString('1970-01-01 00:00:00 UTC'), DateTime::fromString('1958-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::UNIX(), TimeEpoch::GPS(), DateTime::fromString('1970-01-01 00:00:00 UTC'), DateTime::fromString('1980-01-06 00:00:00 UTC')];
+        yield [TimeEpoch::POSIX(), TimeEpoch::POSIX(), DateTime::fromString('1970-01-01 00:00:00 UTC'), DateTime::fromString('1970-01-01 00:00:00 UTC')];
+
+        yield [TimeEpoch::TAI(), TimeEpoch::UTC(), DateTime::fromString('1958-01-01 00:00:00 UTC'), DateTime::fromString('1972-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::TAI(), TimeEpoch::GPS(), DateTime::fromString('1958-01-01 00:00:00 UTC'), DateTime::fromString('1980-01-06 00:00:00 UTC')];
+        yield [TimeEpoch::TAI(), TimeEpoch::UNIX(), DateTime::fromString('1958-01-01 00:00:00 UTC'), DateTime::fromString('1970-01-01 00:00:00 UTC')];
+        yield [TimeEpoch::TAI(), TimeEpoch::TAI(), DateTime::fromString('1958-01-01 00:00:00 UTC'), DateTime::fromString('1958-01-01 00:00:00 UTC')];
+    }
+}

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodTest.php
@@ -32,16 +32,6 @@ final class TimePeriodTest extends TestCase
         $this->assertSame("2.508825", $period->distance()->inSecondsPreciseString());
     }
 
-    public function test_precise_distance_in_time_unit_from_start_to_end_backward() : void
-    {
-        $period = new TimePeriod(
-            DateTime::fromString('2020-01-01 12:25:30.079635'),
-            DateTime::fromString('2020-01-01 12:25:32.588460')
-        );
-
-        $this->assertSame("-2.508825", $period->distanceBackward()->inSecondsPreciseString());
-    }
-
     public function test_distance_in_time_unit_from_start_to_end_date_between_years() : void
     {
         $period = new TimePeriod(
@@ -52,18 +42,6 @@ final class TimePeriodTest extends TestCase
         $this->assertSame(DateTime::fromString('2020-01-01 00:00:00.0000')->year()->numberOfDays(), $period->distance()->inDays());
         $this->assertFalse($period->distance()->isNegative());
         $this->assertTrue(DateTime::fromString('2020-01-01 00:00:00.0000')->year()->isLeap());
-    }
-
-    public function test_distance_in_time_unit_from_end_to_start_date() : void
-    {
-        $period = new TimePeriod(
-            DateTime::fromString('2020-01-01 00:00:00.0000'),
-            DateTime::fromString('2020-01-02 00:00:00.0000')
-        );
-
-        $this->assertSame(-86400, $period->distanceBackward()->inSeconds());
-        $this->assertSame(86400, $period->distanceBackward()->inSecondsAbs());
-        $this->assertTrue($period->distanceBackward()->isNegative());
     }
 
     public function test_iterating_through_day_by_hour() : void

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodsTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodsTest.php
@@ -14,7 +14,7 @@ final class TimePeriodsTest extends TestCase
     public function test_offset_exists() : void
     {
         $timePeriods = DateTime::fromString('2020-01-01 00:00:00.000000')
-            ->to(DateTime::fromString('2020-01-01 01:00:00.000000'))
+            ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
             ->iterate(TimeUnit::minute());
 
         $this->assertFalse(isset($timePeriods[5000]));
@@ -23,7 +23,7 @@ final class TimePeriodsTest extends TestCase
     public function test_offset_set() : void
     {
         $timePeriods = DateTime::fromString('2020-01-01 00:00:00.000000')
-            ->to(DateTime::fromString('2020-01-01 01:00:00.000000'))
+            ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
             ->iterate(TimeUnit::minute());
 
         $this->expectExceptionMessage('Aeon\Calendar\Gregorian\TimePeriods is immutable.');
@@ -37,7 +37,7 @@ final class TimePeriodsTest extends TestCase
     public function test_offset_unset() : void
     {
         $timePeriods = DateTime::fromString('2020-01-01 00:00:00.000000')
-            ->to(DateTime::fromString('2020-01-01 01:00:00.000000'))
+            ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
             ->iterate(TimeUnit::minute());
 
         $this->expectExceptionMessage('Aeon\Calendar\Gregorian\TimePeriods is immutable.');
@@ -49,7 +49,7 @@ final class TimePeriodsTest extends TestCase
     {
         $counter = 0;
         DateTime::fromString('2020-01-01 00:00:00.000000')
-            ->to(DateTime::fromString('2020-01-01 01:00:00.000000'))
+            ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
             ->iterate(TimeUnit::minute())
             ->each(function (TimePeriod $timePeriod) use (&$counter) : void {
                 /** @psalm-suppress MixedOperand */
@@ -62,7 +62,7 @@ final class TimePeriodsTest extends TestCase
     public function test_get_iterator() : void
     {
         $timePeriods = DateTime::fromString('2020-01-01 00:00:00.000000')
-            ->to(DateTime::fromString('2020-01-01 01:00:00.000000'))
+            ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
             ->iterate(TimeUnit::minute());
 
         $this->assertSame($timePeriods->all(), (array) $timePeriods->getIterator());


### PR DESCRIPTION
This PR brings support for the leap seconds (optional) to the library. I got inspired by one comment at Reddit where someone made a point that not all das are 86400 seconds long which makes this library not prepared for the production use cases. As much as I don't believe that lack of support for leaps seconds would make it any worse I really enjoyed whole research and implementation so thank you!  
It also adds a possibility to convert DateTime into timestamps since different epochs. 
Leap seconds awareness makes also possible to transform time into GPS (@styxiak thanks again for the inspiration!) or Atomic Time.
Leap seconds are making also this library more dependent on IERS leap seconds announcements but those happen only once every 6 months and tests are made to break few days before new announcement so it should be really easy to catch up.    