### PR TITLE
Drop webmozart/assert dependnecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,13 @@
     "keywords": ["calendar", "immutable", "holidays", "sleep"],
     "prefer-stable": true,
     "require": {
-        "php": ">=7.4.2",
-        "webmozart/assert": "^1.3"
+        "php": ">=7.4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.1",
         "phpstan/phpstan": "^0.12.26",
         "vimeo/psalm": "^3.11",
         "phpstan/phpstan-phpunit": "^0.12.8",
-        "phpstan/phpstan-webmozart-assert": "^0.12.4",
         "psalm/plugin-phpunit": "^0.10.1",
         "friendsofphp/php-cs-fixer": "^2.16.3",
         "infection/infection": "^0.16.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,141 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7855f03a7ec5332c08688c91f2deb17f",
-    "packages": [
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.17.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
-                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.17-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.17.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-06-06T08:46:27+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
-                "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/1.9.0"
-            },
-            "time": "2020-06-16T10:16:42+00:00"
-        }
-    ],
+    "content-hash": "abee838dd1209d13b02b575d222df996",
+    "packages": [],
     "packages-dev": [
         {
             "name": "amphp/amp",
@@ -747,16 +614,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.16.3",
+            "version": "v2.16.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "83baf823a33a1cbd5416c8626935cf3f843c10b0"
+                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/83baf823a33a1cbd5416c8626935cf3f843c10b0",
-                "reference": "83baf823a33a1cbd5416c8626935cf3f843c10b0",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/1023c3458137ab052f6ff1e09621a721bfdeca13",
+                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13",
                 "shasum": ""
             },
             "require": {
@@ -788,12 +655,12 @@
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
                 "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
                 "phpunitgoodpractices/traits": "^1.8",
-                "symfony/phpunit-bridge": "^4.3 || ^5.0",
+                "symfony/phpunit-bridge": "^5.1",
                 "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
-                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "ext-mbstring": "For handling non-UTF8 characters.",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
                 "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
@@ -836,7 +703,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.3"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4"
             },
             "funding": [
                 {
@@ -844,7 +711,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-04-15T18:51:10+00:00"
+            "time": "2020-06-27T23:57:46+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -1168,20 +1035,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.5",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "replace": {
                 "myclabs/deep-copy": "self.version"
@@ -1214,9 +1081,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.9.5"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
             },
-            "time": "2020-01-17T21:11:47+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-29T13:22:24+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1271,16 +1144,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.5.0",
+            "version": "v4.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "53c2753d756f5adb586dca79c2ec0e2654dd9463"
+                "reference": "c346bbfafe2ff60680258b631afb730d186ed864"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/53c2753d756f5adb586dca79c2ec0e2654dd9463",
-                "reference": "53c2753d756f5adb586dca79c2ec0e2654dd9463",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c346bbfafe2ff60680258b631afb730d186ed864",
+                "reference": "c346bbfafe2ff60680258b631afb730d186ed864",
                 "shasum": ""
             },
             "require": {
@@ -1321,9 +1194,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.5.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.6.0"
             },
-            "time": "2020-06-03T07:24:19+00:00"
+            "time": "2020-07-02T17:12:47+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -1731,25 +1604,25 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -1778,9 +1651,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
             },
-            "time": "2020-04-27T09:25:28+00:00"
+            "time": "2020-06-27T09:03:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1841,25 +1714,24 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "30441f2752e493c639526b215ed81d54f369d693"
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/30441f2752e493c639526b215ed81d54f369d693",
-                "reference": "30441f2752e493c639526b215ed81d54f369d693",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
+                "php": "^7.2 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.2",
-                "mockery/mockery": "~1"
+                "ext-tokenizer": "*"
             },
             "type": "library",
             "extra": {
@@ -1887,7 +1759,7 @@
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.x"
             },
-            "time": "2020-06-19T20:22:09+00:00"
+            "time": "2020-06-27T10:12:23+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1958,16 +1830,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.31",
+            "version": "0.12.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "776c8056b401e1b67f277b9e9fb334d1a274671d"
+                "reference": "d03863f504c8432b3de4d1881f73f6acb8c0e67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/776c8056b401e1b67f277b9e9fb334d1a274671d",
-                "reference": "776c8056b401e1b67f277b9e9fb334d1a274671d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d03863f504c8432b3de4d1881f73f6acb8c0e67c",
+                "reference": "d03863f504c8432b3de4d1881f73f6acb8c0e67c",
                 "shasum": ""
             },
             "require": {
@@ -1998,7 +1870,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.31"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.32"
             },
             "funding": [
                 {
@@ -2014,7 +1886,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-24T20:55:29+00:00"
+            "time": "2020-07-01T11:57:52+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2075,63 +1947,6 @@
                 "source": "https://github.com/phpstan/phpstan-phpunit/tree/0.12.11"
             },
             "time": "2020-06-01T16:43:31+00:00"
-        },
-        {
-            "name": "phpstan/phpstan-webmozart-assert",
-            "version": "0.12.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan-webmozart-assert.git",
-                "reference": "86b102cd19eeacc3b7b3d26a057555cc7cff67b9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-webmozart-assert/zipball/86b102cd19eeacc3b7b3d26a057555cc7cff67b9",
-                "reference": "86b102cd19eeacc3b7b3d26a057555cc7cff67b9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~7.1",
-                "phpstan/phpstan": "^0.12.24"
-            },
-            "require-dev": {
-                "consistence/coding-standard": "^3.7",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-                "ergebnis/composer-normalize": "^2.0.2",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan-phpunit": "^0.12.6",
-                "phpstan/phpstan-strict-rules": "^0.12.1",
-                "phpunit/phpunit": "^7.5.18",
-                "slevomat/coding-standard": "^4.5.2",
-                "webmozart/assert": "^1.7.0"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.12-dev"
-                },
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPStan webmozart/assert extension",
-            "support": {
-                "issues": "https://github.com/phpstan/phpstan-webmozart-assert/issues",
-                "source": "https://github.com/phpstan/phpstan-webmozart-assert/tree/0.12.6"
-            },
-            "time": "2020-06-06T18:10:56+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2450,21 +2265,21 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "4.0.2",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e61c593e9734b47ef462340c24fca8d6a57da14e"
+                "reference": "5672711b6b07b14d5ab694e700c62eeb82fcf374"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e61c593e9734b47ef462340c24fca8d6a57da14e",
-                "reference": "e61c593e9734b47ef462340c24fca8d6a57da14e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/5672711b6b07b14d5ab694e700c62eeb82fcf374",
+                "reference": "5672711b6b07b14d5ab694e700c62eeb82fcf374",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.3"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.0"
@@ -2505,7 +2320,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-16T07:00:44+00:00"
+            "time": "2020-06-27T06:36:25+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -3064,20 +2879,20 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3e523c576f29dacecff309f35e4cc5a5c168e78a"
+                "reference": "1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3e523c576f29dacecff309f35e4cc5a5c168e78a",
-                "reference": "3e523c576f29dacecff309f35e4cc5a5c168e78a",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113",
+                "reference": "1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.0",
@@ -3118,7 +2933,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/master"
             },
             "funding": [
                 {
@@ -3126,7 +2941,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-05-08T05:01:12+00:00"
+            "time": "2020-06-30T04:46:02+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -3558,16 +3373,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.1.1",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "56b3ba194e0cbaaf3de7ccd353c289d7a84ed022"
+                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/56b3ba194e0cbaaf3de7ccd353c289d7a84ed022",
-                "reference": "56b3ba194e0cbaaf3de7ccd353c289d7a84ed022",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/86991e2b33446cd96e648c18bcdb1e95afb2c05a",
+                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a",
                 "shasum": ""
             },
             "require": {
@@ -3579,7 +3394,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
@@ -3602,7 +3417,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/master"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.2.1"
             },
             "funding": [
                 {
@@ -3610,7 +3425,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-26T12:17:54+00:00"
+            "time": "2020-07-05T08:31:53+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4256,6 +4071,85 @@
                 }
             ],
             "time": "2020-05-23T13:08:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.17.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -5296,16 +5190,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.12.1",
+            "version": "3.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "9b860214d58c48b5cbe99bdb17914d0eb723c9cd"
+                "reference": "7c7ebd068f8acaba211d4a2c707c4ba90874fa26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9b860214d58c48b5cbe99bdb17914d0eb723c9cd",
-                "reference": "9b860214d58c48b5cbe99bdb17914d0eb723c9cd",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/7c7ebd068f8acaba211d4a2c707c4ba90874fa26",
+                "reference": "7c7ebd068f8acaba211d4a2c707c4ba90874fa26",
                 "shasum": ""
             },
             "require": {
@@ -5391,9 +5285,62 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/3.12.1"
+                "source": "https://github.com/vimeo/psalm/tree/master"
             },
-            "time": "2020-06-23T00:24:34+00:00"
+            "time": "2020-07-03T16:59:07+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/1.9.0"
+            },
+            "time": "2020-06-16T10:16:42+00:00"
         },
         {
             "name": "webmozart/glob",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,6 @@
 parameters:
-    level: 8
+    level: max
     paths:
         - src
 
     tmpDir: var/phpstan/cache
-
-includes:
-    - vendor/phpstan/phpstan-webmozart-assert/extension.neon

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Aeon\Calendar\Gregorian;
 
 use Aeon\Calendar\Exception\Exception;
+use Aeon\Calendar\Exception\InvalidArgumentException;
 use Aeon\Calendar\Gregorian\TimeZone\TimeOffset;
 use Aeon\Calendar\TimeUnit;
-use Webmozart\Assert\Assert;
 
 /**
  * @psalm-immutable
@@ -30,20 +30,18 @@ final class DateTime
     public function __construct(Day $day, Time $time, ?TimeZone $timeZone = null, ?TimeOffset $timeOffset = null)
     {
         if ($timeZone !== null && $timeOffset !== null) {
-            Assert::same(
-                $timeZone->toDateTimeZone()->getOffset(
-                    $day->toDateTimeImmutable()
+            if ($timeZone->toDateTimeZone()->getOffset(
+                $day->toDateTimeImmutable()
                         ->setTimeZone($timeZone->toDateTimeZone())
                         ->setTime($time->hour(), $time->minute(), $time->second())
-                ),
-                $timeOffset->toTimeUnit()->inSeconds(),
-                \sprintf(
+            ) !== $timeOffset->toTimeUnit()->inSeconds()) {
+                throw new InvalidArgumentException(\sprintf(
                     "TimeOffset %s does not match TimeZone %s at %s",
                     $timeOffset->toString(),
                     $timeZone->name(),
                     $day->toDateTimeImmutable()->setTimeZone($timeZone->toDateTimeZone())->setTime($time->hour(), $time->minute(), $time->second())->format('Y-m-d H:i:s')
-                )
-            );
+                ));
+            }
         }
 
         $this->day = $day;

--- a/src/Aeon/Calendar/Gregorian/Day.php
+++ b/src/Aeon/Calendar/Gregorian/Day.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian;
 
+use Aeon\Calendar\Exception\InvalidArgumentException;
 use Aeon\Calendar\Gregorian\Day\WeekDay;
-use Webmozart\Assert\Assert;
 
 /**
  * @psalm-immutable
@@ -18,8 +18,9 @@ final class Day
 
     public function __construct(Month $month, int $number)
     {
-        Assert::greaterThan($number, 0);
-        Assert::lessThanEq($number, $month->numberOfDays());
+        if ($number <= 0 || $number > $month->numberOfDays()) {
+            throw new InvalidArgumentException("Day number must be greater or equal 1 and less or equal than " . $month->numberOfDays());
+        }
 
         $this->number = $number;
         $this->month = $month;

--- a/src/Aeon/Calendar/Gregorian/Day/WeekDay.php
+++ b/src/Aeon/Calendar/Gregorian/Day/WeekDay.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian\Day;
 
-use Webmozart\Assert\Assert;
+use Aeon\Calendar\Exception\InvalidArgumentException;
 
 /**
  * @psalm-immutable
@@ -35,8 +35,9 @@ final class WeekDay
 
     public function __construct(int $number)
     {
-        Assert::greaterThanEq($number, 1);
-        Assert::lessThanEq($number, 7);
+        if ($number <= 0 || $number > 7) {
+            throw new InvalidArgumentException("Day number must be greater or equal 1 and less or equal than 7");
+        }
 
         $this->number = $number;
     }

--- a/src/Aeon/Calendar/Gregorian/LeapSecond.php
+++ b/src/Aeon/Calendar/Gregorian/LeapSecond.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian;
 
+use Aeon\Calendar\Exception\InvalidArgumentException;
 use Aeon\Calendar\TimeUnit;
-use Webmozart\Assert\Assert;
 
 /**
  * @psalm-immutable
@@ -24,7 +24,10 @@ final class LeapSecond
 
     public function __construct(DateTime $dateTime, TimeUnit $offsetTAI)
     {
-        Assert::greaterThanEq($offsetTAI->inSeconds(), 10);
+        if ($offsetTAI->inSeconds() < 10) {
+            throw new InvalidArgumentException("Leap second TAI offset must be greater or equal 10");
+        }
+
         $this->dateTime = $dateTime;
         $this->offsetTAI = $offsetTAI;
     }

--- a/src/Aeon/Calendar/Gregorian/Month.php
+++ b/src/Aeon/Calendar/Gregorian/Month.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian;
 
-use Webmozart\Assert\Assert;
+use Aeon\Calendar\Exception\InvalidArgumentException;
 
 /**
  * @psalm-immutable
@@ -19,8 +19,9 @@ final class Month
 
     public function __construct(Year $year, int $number)
     {
-        Assert::greaterThan($number, 0);
-        Assert::lessThanEq($number, 12);
+        if ($number <= 0 || $number > 12) {
+            throw new InvalidArgumentException("Month number must be greater or equal 1 and less or equal than 12");
+        }
 
         $this->year = $year;
         $this->number = $number;

--- a/src/Aeon/Calendar/Gregorian/Months.php
+++ b/src/Aeon/Calendar/Gregorian/Months.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian;
 
-use Webmozart\Assert\Assert;
-
 /**
  * @psalm-immutable
  */
@@ -25,9 +23,6 @@ final class Months implements \Countable
 
     public function byNumber(int $number) : Month
     {
-        Assert::greaterThan($number, 0);
-        Assert::lessThanEq($number, 12);
-
         return new Month($this->year, $number);
     }
 

--- a/src/Aeon/Calendar/Gregorian/Time.php
+++ b/src/Aeon/Calendar/Gregorian/Time.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian;
 
+use Aeon\Calendar\Exception\InvalidArgumentException;
 use Aeon\Calendar\TimeUnit;
-use Webmozart\Assert\Assert;
 
 /**
  * @psalm-immutable
@@ -22,14 +22,21 @@ final class Time
 
     public function __construct(int $hour, int $minute, int $second, int $microsecond = 0)
     {
-        Assert::greaterThanEq($hour, 0);
-        Assert::lessThanEq($hour, 23);
-        Assert::greaterThanEq($minute, 0);
-        Assert::lessThanEq($minute, 60);
-        Assert::greaterThanEq($second, 0);
-        Assert::lessThanEq($second, 60);
-        Assert::greaterThanEq($microsecond, 0);
-        Assert::lessThan($microsecond, 1000000);
+        if ($hour < 0 || $hour > 23) {
+            throw new InvalidArgumentException("Hour must be greater or equal 0 and less or equal than 23");
+        }
+
+        if ($minute < 0 || $minute >= 60) {
+            throw new InvalidArgumentException("Minut must be greater or equal 0 and less than 60");
+        }
+
+        if ($second < 0 || $second >= 60) {
+            throw new InvalidArgumentException("Second must be greater or equal 0 and less than 60");
+        }
+
+        if ($microsecond < 0 || $microsecond >= 1000000) {
+            throw new InvalidArgumentException("Microsecond must be greater or equal 0 and less than 1000000");
+        }
 
         $this->hour = $hour;
         $this->minute = $minute;

--- a/src/Aeon/Calendar/Gregorian/TimeEpoch.php
+++ b/src/Aeon/Calendar/Gregorian/TimeEpoch.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian;
 
+use Aeon\Calendar\Exception\InvalidArgumentException;
 use Aeon\Calendar\TimeUnit;
-use Webmozart\Assert\Assert;
 
 /**
  * @psalm-immutable
@@ -26,7 +26,10 @@ final class TimeEpoch
 
     private function __construct(int $type, DateTime $dateTime)
     {
-        Assert::true($dateTime->timeOffset()->isUTC());
+        if (!$dateTime->timeOffset()->isUTC()) {
+            throw new InvalidArgumentException("DateTime must have UTC time offset, got " . $dateTime->timeOffset()->toString());
+        }
+
         $this->type = $type;
         $this->dateTime = $dateTime;
     }

--- a/src/Aeon/Calendar/Gregorian/TimeZone.php
+++ b/src/Aeon/Calendar/Gregorian/TimeZone.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian;
 
+use Aeon\Calendar\Exception\InvalidArgumentException;
 use Aeon\Calendar\Gregorian\TimeZone\TimeOffset;
 use Aeon\Calendar\TimeUnit;
-use Webmozart\Assert\Assert;
 
 /**
  * @psalm-immutable
@@ -873,17 +873,16 @@ final class TimeZone
 
     public function __construct(string $name)
     {
-        Assert::true(
-            \in_array(
-                $name,
-                \array_merge(
-                    (array) \DateTimeZone::listIdentifiers(),
-                    [self::AMERICA_GODTHAB, self::PACIFIC_JOHNSTON]
-                ),
-                true,
+        if (!\in_array(
+            $name,
+            \array_merge(
+                (array) \DateTimeZone::listIdentifiers(),
+                [self::AMERICA_GODTHAB, self::PACIFIC_JOHNSTON]
             ),
-            "\"$name\" is not a valid timezone."
-        );
+            true,
+        )) {
+            throw new InvalidArgumentException("\"$name\" is not a valid timezone.");
+        }
 
         $this->name = $name;
     }

--- a/src/Aeon/Calendar/Gregorian/TimeZone/TimeOffset.php
+++ b/src/Aeon/Calendar/Gregorian/TimeZone/TimeOffset.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Aeon\Calendar\Gregorian\TimeZone;
 
+use Aeon\Calendar\Exception\InvalidArgumentException;
 use Aeon\Calendar\TimeUnit;
-use Webmozart\Assert\Assert;
 
 /**
  * @psalm-immutable
@@ -22,8 +22,9 @@ final class TimeOffset
 
     private function __construct(bool $negative, int $hours, int $minutes)
     {
-        Assert::greaterThanEq($minutes, 0);
-        Assert::lessThanEq($minutes, 60);
+        if ($minutes < 0 || $minutes >= 60) {
+            throw new InvalidArgumentException("Minutes must be greater or equal 0 and less than 60");
+        }
 
         $this->negative = $negative;
         $this->hours = $hours;
@@ -39,9 +40,9 @@ final class TimeOffset
     /** @psalm-pure */
     public static function fromString(string $offset) : self
     {
-        Assert::regex($offset, self::OFFSET_REGEXP, "\"$offset\" is not a valid UTC Offset.");
-
-        \preg_match(self::OFFSET_REGEXP, $offset, $matches);
+        if (!\preg_match(self::OFFSET_REGEXP, $offset, $matches)) {
+            throw new InvalidArgumentException("\"$offset\" is not a valid UTC Offset.");
+        }
 
         return new self($matches[1] === '-', (int) $matches[2], (int) $matches[3]);
     }

--- a/src/Aeon/Calendar/TimeUnit.php
+++ b/src/Aeon/Calendar/TimeUnit.php
@@ -6,7 +6,6 @@ namespace Aeon\Calendar;
 
 use Aeon\Calendar\Exception\Exception;
 use Aeon\Calendar\Exception\InvalidArgumentException;
-use Webmozart\Assert\Assert;
 
 /**
  * @psalm-immutable
@@ -31,15 +30,18 @@ final class TimeUnit
 
     private bool $negative;
 
-    private function __construct(bool $negative, int $seconds, int $microseconds)
+    private function __construct(bool $negative, int $seconds, int $microsecond)
     {
-        Assert::greaterThanEq($seconds, 0);
-        Assert::greaterThanEq($microseconds, 0);
-        Assert::lessThan($microseconds, self::MICROSECONDS_IN_SECOND);
+        if ($seconds < 0) {
+            throw new InvalidArgumentException("Seconds must be greater or equal 0, got " . $seconds);
+        }
+        if ($microsecond < 0 || $microsecond >= self::MICROSECONDS_IN_SECOND) {
+            throw new InvalidArgumentException("Microsecond must be greater or equal 0 and less than 1000000, got " . $seconds);
+        }
 
         $this->negative = $negative;
         $this->seconds = $seconds;
-        $this->microsecond = $microseconds;
+        $this->microsecond = $microsecond;
     }
 
     /**


### PR DESCRIPTION
This PR drops webmozart/assert dependency (which is amazing library that allowed me to bootstrap this lib really quick) in order to not introduce any external dependencies into the projects that will decide to use aeon/calendar (or any other lib from aeon). 
All assertions in this and other aeon libraries are really simple so replacing them with regular if statements throwing simple exception was no brainer. 

From now I would like to keep aeon libraries dependencies free unless:

* lib is a bridge for another library/framework (like https://github.com/aeon-php/calendar-holidays-yasumi) 
* it's aeon dependency like https://github.com/aeon-php/calendar 
* it's a PSR (or any other commonly used standard) dependency that provides an interface rather than real implementation giving by this freedom to the user to choose their own implementations. 