### PR TITLE
Improved toISO8601 DateTime conversion

### DIFF
--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -182,9 +182,11 @@ final class DateTime
         return self::fromDateTime($this->toDateTimeImmutable()->setTimezone($dateTimeZone->toDateTimeZone()));
     }
 
-    public function toISO8601() : string
+    public function toISO8601(bool $extended = true) : string
     {
-        return $this->toDateTimeImmutable()->format(\DateTimeInterface::ISO8601);
+        return $extended
+            ? $this->toDateTimeImmutable()->format('Y-m-d\TH:i:sP')
+            : $this->toDateTimeImmutable()->format('Ymd\THisO');
     }
 
     public function isDaylightSaving() : bool

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -94,6 +94,12 @@ final class DateTimeTest extends TestCase
         $this->assertSame($dateTime->toISO8601(), $dateTime->__toString());
     }
 
+    public function test_to_iso8601_basic_format() : void
+    {
+        $dateTime = DateTime::fromString('2020-01-01 00:00:00+00');
+        $this->assertSame('20200101T000000+0000', $dateTime->toISO8601($extended = false));
+    }
+
     public function test_create() : void
     {
         $this->assertTrue(
@@ -219,20 +225,20 @@ final class DateTimeTest extends TestCase
     {
         $now = DateTime::fromString('2020-06-17 20:57:07 UTC');
 
-        $this->assertSame('2020-06-17T20:57:44+0000', $now->toAtomicTime()->toISO8601());
+        $this->assertSame('2020-06-17T20:57:44+00:00', $now->toAtomicTime()->toISO8601());
     }
 
     public function test_to_gps_time() : void
     {
         $now = DateTime::fromString('2020-06-17 20:57:07 UTC');
 
-        $this->assertSame('2020-06-17T20:57:25+0000', $now->toGPSTime()->toISO8601());
+        $this->assertSame('2020-06-17T20:57:25+00:00', $now->toGPSTime()->toISO8601());
     }
 
     public function test_timestamp_before_epoch_start() : void
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Given epoch started at 1970-01-01T00:00:00+0000 which was after 1969-01-01T00:00:00+0000');
+        $this->expectExceptionMessage('Given epoch started at 1970-01-01T00:00:00+00:00 which was after 1969-01-01T00:00:00+00:00');
 
         $dateTime = DateTime::fromString('1969-01-01 00:00:00 UTC');
 
@@ -601,21 +607,21 @@ final class DateTimeTest extends TestCase
 
     public function test_yesterday() : void
     {
-        $this->assertSame('2019-12-31T00:00:00+0000', DateTime::fromString('2020-01-01 01:00:00')->yesterday()->toISO8601());
+        $this->assertSame('2019-12-31T00:00:00+00:00', DateTime::fromString('2020-01-01 01:00:00')->yesterday()->toISO8601());
     }
 
     public function test_yesterday_with_tz() : void
     {
-        $this->assertSame('2019-12-31T00:00:00+0100', DateTime::fromString('2020-01-01 01:00:00 Europe/Warsaw')->yesterday()->toISO8601());
+        $this->assertSame('2019-12-31T00:00:00+01:00', DateTime::fromString('2020-01-01 01:00:00 Europe/Warsaw')->yesterday()->toISO8601());
     }
 
     public function test_tomorrow() : void
     {
-        $this->assertSame('2020-01-02T00:00:00+0000', DateTime::fromString('2020-01-01 01:00:00')->tomorrow()->toISO8601());
+        $this->assertSame('2020-01-02T00:00:00+00:00', DateTime::fromString('2020-01-01 01:00:00')->tomorrow()->toISO8601());
     }
 
     public function test_tomorrow_with_tz() : void
     {
-        $this->assertSame('2020-01-02T00:00:00+0100', DateTime::fromString('2020-01-01 01:00:00 Europe/Warsaw')->tomorrow()->toISO8601());
+        $this->assertSame('2020-01-02T00:00:00+01:00', DateTime::fromString('2020-01-01 01:00:00 Europe/Warsaw')->tomorrow()->toISO8601());
     }
 }

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
@@ -16,14 +16,14 @@ final class DayTest extends TestCase
     {
         $day = Day::fromString('2020-01-01');
 
-        $this->assertSame('2020-01-01T00:00:00+0000', $day->midnight(TimeZone::UTC())->toISO8601());
+        $this->assertSame('2020-01-01T00:00:00+00:00', $day->midnight(TimeZone::UTC())->toISO8601());
     }
 
     public function test_noon() : void
     {
         $day = Day::fromString('2020-01-01');
 
-        $this->assertSame('2020-01-01T12:00:00+0000', $day->noon(TimeZone::UTC())->toISO8601());
+        $this->assertSame('2020-01-01T12:00:00+00:00', $day->noon(TimeZone::UTC())->toISO8601());
     }
 
     public function test_end_of_day() : void


### PR DESCRIPTION
https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.iso8601 so even that PHP docs says that ISO8601 constant is invalid (which is not really true, it might be inaccurate but not really invalid) following https://www.w3.org/TR/NOTE-datetime which says that there are many valid formats defined by ISO8601, like:

> For example it defines Basic Format, without punctuation, and Extended Format

`DateTime::toISO8601(bool $extended = true)` will now get additional parameter that will define if we want to get extended or basic IS8601 format.

Extended format matches \DateTimeInterface::ATOM, basic is \DateTimeInterface::ISO8601 without punctuation.

* Extended: `Y-m-d\TH:i:sP` - `2020-01-01T00:00:00+00:00`   
* Basic: `Ymd\THisO` - `20200101T000000+0000` 