### PR TITLE
TimePeriod::overlaps performance improvements

### DIFF
--- a/benchmark/Aeon/Calendar/Benchmark/Gregorian/DateTimeBench.php
+++ b/benchmark/Aeon/Calendar/Benchmark/Gregorian/DateTimeBench.php
@@ -13,13 +13,20 @@ use Aeon\Calendar\Gregorian\DateTime;
  */
 final class DateTimeBench
 {
+    private DateTime $dateTime;
+
+    public function __construct()
+    {
+        $this->dateTime = DateTime::fromString('2020-01-01');
+    }
+
     public function bench_unix_timestamp() : void
     {
-        DateTime::fromString('2020-01-01')->timestampUNIX();
+        $this->dateTime->timestampUNIX();
     }
 
     public function bench_to_datetime_immutable() : void
     {
-        DateTime::fromString('2020-01-01')->toDateTimeImmutable();
+        $this->dateTime->toDateTimeImmutable();
     }
 }

--- a/benchmark/Aeon/Calendar/Benchmark/Gregorian/DayBench.php
+++ b/benchmark/Aeon/Calendar/Benchmark/Gregorian/DayBench.php
@@ -13,13 +13,48 @@ use Aeon\Calendar\Gregorian\Day;
  */
 final class DayBench
 {
+    private Day $day;
+
+    private Day $futureDay;
+
+    public function __construct()
+    {
+        $this->day = Day::fromString('2020-01-01');
+        $this->futureDay = Day::fromString('2020-01-06');
+    }
+
     public function bench_time_between() : void
     {
-        Day::fromString('2020-01-01')->timeBetween(Day::fromString('2020-01-06'))->inDays();
+        $this->day->timeBetween($this->futureDay)->inDays();
     }
 
     public function bench_to_datetime_immutable() : void
     {
-        Day::fromString('2020-01-01')->toDateTimeImmutable();
+        $this->day->toDateTimeImmutable();
+    }
+
+    public function bench_is_equal() : void
+    {
+        $this->day->isEqual($this->futureDay);
+    }
+
+    public function bench_is_before() : void
+    {
+        $this->day->isBefore($this->futureDay);
+    }
+
+    public function bench_is_after() : void
+    {
+        $this->day->isAfter($this->futureDay);
+    }
+
+    public function bench_is_before_eq() : void
+    {
+        $this->day->isBeforeOrEqual($this->futureDay);
+    }
+
+    public function bench_is_after_eq() : void
+    {
+        $this->day->isAfterOrEqual($this->futureDay);
     }
 }

--- a/benchmark/Aeon/Calendar/Benchmark/Gregorian/DayIterationBench.php
+++ b/benchmark/Aeon/Calendar/Benchmark/Gregorian/DayIterationBench.php
@@ -18,15 +18,12 @@ final class DayIterationBench
     public function bench_iteration_over_last_half_of_the_year_multiple_times() : void
     {
         $end = GregorianCalendar::UTC()->currentDay();
-        $middle = $end->minusMonths(3);
         $start = $end->minusMonths(6);
 
         for ($index = 0; $index < 20; $index++) {
             foreach ($start->until($end)->all() as $nextDay) {
-                if ($nextDay->isAfter($middle)) {
-                    (new TimePeriod($nextDay->midnight($tz = TimeZone::UTC()), $nextDay->next()->midnight($tz)))
-                        ->overlaps(new TimePeriod($nextDay->midnight($tz), $nextDay->previous()->midnight($tz)));
-                }
+                (new TimePeriod($nextDay->midnight($tz = TimeZone::UTC()), $nextDay->next()->midnight($tz)))
+                    ->overlaps(new TimePeriod($nextDay->midnight($tz), $nextDay->previous()->midnight($tz)));
             }
         }
     }

--- a/benchmark/Aeon/Calendar/Benchmark/Gregorian/TimePeriodBench.php
+++ b/benchmark/Aeon/Calendar/Benchmark/Gregorian/TimePeriodBench.php
@@ -14,17 +14,23 @@ use Aeon\Calendar\Gregorian\TimePeriod;
  */
 final class TimePeriodBench
 {
+    private TimePeriod $firstPeriod;
+
+    private TimePeriod $secondPeriod;
+
+    public function __construct()
+    {
+        $this->firstPeriod = new TimePeriod(DateTime::fromString('2020-01-01 00:00:00'), DateTime::fromString('2020-01-06 00:00:00'));
+        $this->secondPeriod =  new TimePeriod(DateTime::fromString('2020-01-04 00:00:00'), DateTime::fromString('2020-01-08 00:00:00'));
+    }
+
     public function bench_distance() : void
     {
-        (new TimePeriod(DateTime::fromString('2020-01-01 00:00:00'), DateTime::fromString('2020-01-06 00:00:00')))
-            ->distance();
+        $this->firstPeriod->distance();
     }
 
     public function bench_overlaps() : void
     {
-        (new TimePeriod(DateTime::fromString('2020-01-01 00:00:00'), DateTime::fromString('2020-01-06 00:00:00')))
-            ->overlaps(
-                new TimePeriod(DateTime::fromString('2020-01-04 00:00:00'), DateTime::fromString('2020-01-08 00:00:00'))
-            );
+        $this->firstPeriod->overlaps($this->secondPeriod);
     }
 }

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -22,6 +22,8 @@ final class DateTime
 
     private TimeOffset $timeOffset;
 
+    private int $unixTimestamp;
+
     /**
      * TimeZone is optional, if not provided it will be set to UTC.
      * DateTime always has TimeOffset but when not provided it's calculated from offset and when
@@ -58,7 +60,11 @@ final class DateTime
                 : TimeOffset::UTC()
             );
 
-        if ($this->time->toString() !== $this->toDateTimeImmutable()->format('H:i:s.u')) {
+        $dateTimeImmutable = $this->toDateTimeImmutable();
+
+        $this->unixTimestamp = $dateTimeImmutable->getTimestamp();
+
+        if ($this->time->toString() !== $dateTimeImmutable->format('H:i:s.u')) {
             $this->time = Time::fromDateTime($this->toDateTimeImmutable());
         }
     }
@@ -238,7 +244,7 @@ final class DateTime
      */
     public function timestampUNIX() : TimeUnit
     {
-        $unixTimestamp = (int) $this->toDateTimeImmutable()->format('U');
+        $unixTimestamp = $this->unixTimestamp;
 
         return $unixTimestamp >= 0
             ? TimeUnit::positive($unixTimestamp, $this->time->microsecond())

--- a/src/Aeon/Calendar/Gregorian/Day.php
+++ b/src/Aeon/Calendar/Gregorian/Day.php
@@ -65,7 +65,7 @@ final class Day
 
     public function timeBetween(self $day) : TimeUnit
     {
-        return TimeUnit::seconds(\abs((int) $this->toDateTimeImmutable()->format('U') - (int) $day->toDateTimeImmutable()->format('U')));
+        return TimeUnit::seconds(\abs(($this->toDateTimeImmutable()->getTimestamp() - $day->toDateTimeImmutable()->getTimestamp())));
     }
 
     public function plus(int $years, int $months, int $days) : self
@@ -194,27 +194,60 @@ final class Day
 
     public function isEqual(self $day) : bool
     {
-        return $this->number() === $day->number();
+        return $this->number() === $day->number()
+            && $this->month()->isEqual($day->month());
     }
 
     public function isBefore(self $day) : bool
     {
-        return $this->toDateTimeImmutable() < $day->toDateTimeImmutable();
+        if ($this->month()->isBefore($day->month())) {
+            return true;
+        }
+
+        if ($this->month()->isAfter($day->month())) {
+            return false;
+        }
+
+        return $this->number() < $day->number();
     }
 
     public function isBeforeOrEqual(self $day) : bool
     {
-        return $this->toDateTimeImmutable() <= $day->toDateTimeImmutable();
+        if ($this->month()->isBefore($day->month())) {
+            return true;
+        }
+
+        if ($this->month()->isAfter($day->month())) {
+            return false;
+        }
+
+        return $this->number() <= $day->number();
     }
 
     public function isAfter(self $day) : bool
     {
-        return $this->toDateTimeImmutable() > $day->toDateTimeImmutable();
+        if ($this->month()->isAfter($day->month())) {
+            return true;
+        }
+
+        if ($this->month()->isBefore($day->month())) {
+            return false;
+        }
+
+        return $this->number() > $day->number();
     }
 
     public function isAfterOrEqual(self $day) : bool
     {
-        return $this->toDateTimeImmutable() >= $day->toDateTimeImmutable();
+        if ($this->month()->isAfter($day->month())) {
+            return true;
+        }
+
+        if ($this->month()->isBefore($day->month())) {
+            return false;
+        }
+
+        return $this->number() >= $day->number();
     }
 
     public function iterate(self $destination) : Days

--- a/src/Aeon/Calendar/Gregorian/Month.php
+++ b/src/Aeon/Calendar/Gregorian/Month.php
@@ -216,26 +216,59 @@ final class Month
 
     public function isEqual(self $month) : bool
     {
-        return $this->toDateTimeImmutable() == $month->toDateTimeImmutable();
+        return $this->number() == $month->number()
+            && $this->year()->isEqual($month->year());
     }
 
     public function isBefore(self $month) : bool
     {
-        return $this->toDateTimeImmutable() < $month->toDateTimeImmutable();
+        if ($this->year()->isBefore($month->year())) {
+            return true;
+        }
+
+        if ($this->year()->isAfter($month->year())) {
+            return false;
+        }
+
+        return $this->number() < $month->number();
     }
 
     public function isBeforeOrEqual(self $month) : bool
     {
-        return $this->toDateTimeImmutable() <= $month->toDateTimeImmutable();
+        if ($this->year()->isBefore($month->year())) {
+            return true;
+        }
+
+        if ($this->year()->isAfter($month->year())) {
+            return false;
+        }
+
+        return $this->number() <= $month->number();
     }
 
     public function isAfter(self $month) : bool
     {
-        return $this->toDateTimeImmutable() > $month->toDateTimeImmutable();
+        if ($this->year()->isAfter($month->year())) {
+            return true;
+        }
+
+        if ($this->year()->isBefore($month->year())) {
+            return false;
+        }
+
+        return $this->number() > $month->number();
     }
 
     public function isAfterOrEqual(self $month) : bool
     {
-        return $this->toDateTimeImmutable() >= $month->toDateTimeImmutable();
+        if ($this->year()->isAfter($month->year())) {
+            return true;
+        }
+
+        if ($this->year()->isBefore($month->year())) {
+            return false;
+        }
+
+        return $this->number() >= $month->number();
     }
 }

--- a/src/Aeon/Calendar/Gregorian/TimePeriod.php
+++ b/src/Aeon/Calendar/Gregorian/TimePeriod.php
@@ -137,42 +137,47 @@ final class TimePeriod
             ? $timePeriod->revert()
             : $timePeriod;
 
-        if ($thisPeriodForward->start()->isBefore($otherPeriodForward->start()) &&
-            $thisPeriodForward->start()->isBefore($otherPeriodForward->end()) &&
-            $thisPeriodForward->end()->isBefore($otherPeriodForward->start()) &&
-            $thisPeriodForward->end()->isBefore($otherPeriodForward->end())
+        $thisPeriodStart = $thisPeriodForward->start()->toDateTimeImmutable();
+        $thisPeriodEnd = $thisPeriodForward->end()->toDateTimeImmutable();
+        $otherPeriodStart = $otherPeriodForward->start()->toDateTimeImmutable();
+        $otherPeriodEnd = $otherPeriodForward->end()->toDateTimeImmutable();
+
+        if ($thisPeriodStart < $otherPeriodStart &&
+            $thisPeriodStart < $otherPeriodEnd &&
+            $thisPeriodEnd < $otherPeriodStart &&
+            $thisPeriodEnd < $otherPeriodEnd
         ) {
             return false;
         }
 
-        if ($thisPeriodForward->start()->isBefore($otherPeriodForward->start()) &&
-            $thisPeriodForward->start()->isBefore($otherPeriodForward->end()) &&
-            $thisPeriodForward->end()->isAfter($otherPeriodForward->start()) &&
-            $thisPeriodForward->end()->isBefore($otherPeriodForward->end())
+        if ($thisPeriodStart < $otherPeriodStart &&
+            $thisPeriodStart < $otherPeriodEnd &&
+            $thisPeriodEnd > $otherPeriodStart &&
+            $thisPeriodEnd < $otherPeriodEnd
         ) {
             return true;
         }
 
-        if ($thisPeriodForward->start()->isAfter($otherPeriodForward->start()) &&
-            $thisPeriodForward->start()->isBefore($otherPeriodForward->end()) &&
-            $thisPeriodForward->end()->isAfter($otherPeriodForward->start()) &&
-            $thisPeriodForward->end()->isBefore($otherPeriodForward->end())
+        if ($thisPeriodStart > $otherPeriodStart &&
+            $thisPeriodStart < $otherPeriodEnd &&
+            $thisPeriodEnd > $otherPeriodStart &&
+            $thisPeriodEnd < $otherPeriodEnd
         ) {
             return true;
         }
 
-        if ($thisPeriodForward->start()->isAfter($otherPeriodForward->start()) &&
-            $thisPeriodForward->start()->isBefore($otherPeriodForward->end()) &&
-            $thisPeriodForward->end()->isAfter($otherPeriodForward->start()) &&
-            $thisPeriodForward->end()->isAfter($otherPeriodForward->end())
+        if ($thisPeriodStart > $otherPeriodStart &&
+            $thisPeriodStart < $otherPeriodEnd &&
+            $thisPeriodEnd > $otherPeriodStart &&
+            $thisPeriodEnd > $otherPeriodEnd
         ) {
             return true;
         }
 
-        if ($thisPeriodForward->start()->isAfter($otherPeriodForward->start()) &&
-            $thisPeriodForward->start()->isAfter($otherPeriodForward->end()) &&
-            $thisPeriodForward->end()->isAfter($otherPeriodForward->start()) &&
-            $thisPeriodForward->end()->isAfter($otherPeriodForward->end())
+        if ($thisPeriodStart > $otherPeriodStart &&
+            $thisPeriodStart > $otherPeriodEnd &&
+            $thisPeriodEnd > $otherPeriodStart &&
+            $thisPeriodEnd > $otherPeriodEnd
         ) {
             return false;
         }

--- a/src/Aeon/Calendar/Gregorian/Year.php
+++ b/src/Aeon/Calendar/Gregorian/Year.php
@@ -198,22 +198,22 @@ final class Year
 
     public function isBefore(self $year) : bool
     {
-        return $this->toDateTimeImmutable() < $year->toDateTimeImmutable();
+        return $this->number() < $year->number();
     }
 
     public function isBeforeOrEqual(self $year) : bool
     {
-        return $this->toDateTimeImmutable() <= $year->toDateTimeImmutable();
+        return $this->number() <= $year->number();
     }
 
     public function isAfter(self $year) : bool
     {
-        return $this->toDateTimeImmutable() > $year->toDateTimeImmutable();
+        return $this->number() > $year->number();
     }
 
     public function isAfterOrEqual(self $year) : bool
     {
-        return $this->toDateTimeImmutable() >= $year->toDateTimeImmutable();
+        return $this->number() >= $year->number();
     }
 
     public function iterate(self $destination) : Years


### PR DESCRIPTION
### Before
```
22 subjects, 110 iterations, 110 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 0.400 [27,863.516 27,911.023] 0.400 (μs)
⅀T: 3,064,986.800μs μSD/r 115.578μs μRSD/r: 2.180%
suite: 1343d13bd3d3c5d171c5a256030ee14cbb5def63, date: 2020-07-23, stime: 08:37:10
+---------------------+-----------------------------------------------------------+------+-----+-----------+
| benchmark           | subject                                                   | revs | its | mean      |
+---------------------+-----------------------------------------------------------+------+-----+-----------+
| InitializationBench | bench_datetime_immutable                                  | 5    | 5   | 0.015ms   |
| InitializationBench | bench_aeon_year                                           | 5    | 5   | 0.061ms   |
| InitializationBench | bench_aeon_month                                          | 5    | 5   | 0.110ms   |
| InitializationBench | bench_aeon_day                                            | 5    | 5   | 0.169ms   |
| InitializationBench | bench_aeon_timezone                                       | 5    | 5   | 0.369ms   |
| InitializationBench | bench_aeon_time                                           | 5    | 5   | 0.038ms   |
| InitializationBench | bench_aeon_datetime_from_datetime_immutable               | 5    | 5   | 0.884ms   |
| InitializationBench | bench_aeon_datetime_create                                | 5    | 5   | 0.679ms   |
| InitializationBench | bench_aeon_datetime_new                                   | 5    | 5   | 0.672ms   |
| InitializationBench | bench_aeon_datetime_from_string                           | 5    | 5   | 0.863ms   |
| DayIterationBench   | bench_iteration_over_last_half_of_the_year_multiple_times | 5    | 5   | 608.973ms |
| DayBench            | bench_time_between                                        | 5    | 5   | 0.063ms   |
| DayBench            | bench_to_datetime_immutable                               | 5    | 5   | 0.002ms   |
| DayBench            | bench_is_equal                                            | 5    | 5   | 0.000ms   |
| DayBench            | bench_is_before                                           | 5    | 5   | 0.004ms   |
| DayBench            | bench_is_after                                            | 5    | 5   | 0.004ms   |
| DayBench            | bench_is_before_eq                                        | 5    | 5   | 0.004ms   |
| DayBench            | bench_is_after_eq                                         | 5    | 5   | 0.004ms   |
| DateTimeBench       | bench_unix_timestamp                                      | 5    | 5   | 0.003ms   |
| DateTimeBench       | bench_to_datetime_immutable                               | 5    | 5   | 0.003ms   |
| TimePeriodBench     | bench_distance                                            | 5    | 5   | 0.016ms   |
| TimePeriodBench     | bench_overlaps                                            | 5    | 5   | 0.062ms   |
+---------------------+-----------------------------------------------------------+------+-----+-----------+
```

### After

```
22 subjects, 110 iterations, 110 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 0.400 [21,142.375 21,184.905] 0.400 (μs)
⅀T: 2,325,661.200μs μSD/r 91.303μs μRSD/r: 1.332%
suite: 1343d13d5bc66218e83ed43cd9333d445ae6ffe5, date: 2020-07-23, stime: 08:38:03
+---------------------+-----------------------------------------------------------+------+-----+-----------+
| benchmark           | subject                                                   | revs | its | mean      |
+---------------------+-----------------------------------------------------------+------+-----+-----------+
| InitializationBench | bench_datetime_immutable                                  | 5    | 5   | 0.015ms   |
| InitializationBench | bench_aeon_year                                           | 5    | 5   | 0.059ms   |
| InitializationBench | bench_aeon_month                                          | 5    | 5   | 0.112ms   |
| InitializationBench | bench_aeon_day                                            | 5    | 5   | 0.171ms   |
| InitializationBench | bench_aeon_timezone                                       | 5    | 5   | 0.374ms   |
| InitializationBench | bench_aeon_time                                           | 5    | 5   | 0.038ms   |
| InitializationBench | bench_aeon_datetime_from_datetime_immutable               | 5    | 5   | 0.899ms   |
| InitializationBench | bench_aeon_datetime_create                                | 5    | 5   | 0.694ms   |
| InitializationBench | bench_aeon_datetime_new                                   | 5    | 5   | 0.696ms   |
| InitializationBench | bench_aeon_datetime_from_string                           | 5    | 5   | 0.871ms   |
| DayIterationBench   | bench_iteration_over_last_half_of_the_year_multiple_times | 5    | 5   | 461.086ms |
| DayBench            | bench_time_between                                        | 5    | 5   | 0.064ms   |
| DayBench            | bench_to_datetime_immutable                               | 5    | 5   | 0.002ms   |
| DayBench            | bench_is_equal                                            | 5    | 5   | 0.000ms   |
| DayBench            | bench_is_before                                           | 5    | 5   | 0.002ms   |
| DayBench            | bench_is_after                                            | 5    | 5   | 0.002ms   |
| DayBench            | bench_is_before_eq                                        | 5    | 5   | 0.002ms   |
| DayBench            | bench_is_after_eq                                         | 5    | 5   | 0.002ms   |
| DateTimeBench       | bench_unix_timestamp                                      | 5    | 5   | 0.001ms   |
| DateTimeBench       | bench_to_datetime_immutable                               | 5    | 5   | 0.003ms   |
| TimePeriodBench     | bench_distance                                            | 5    | 5   | 0.011ms   |
| TimePeriodBench     | bench_overlaps                                            | 5    | 5   | 0.030ms   |
+---------------------+-----------------------------------------------------------+------+-----+-----------+
```