### PR TITLE
Added possibility to define type of the interval when iterating over time periods

### DIFF
--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -525,8 +525,8 @@ final class DateTime
     public function iterate(self $pointInTime, TimeUnit $by) : TimePeriods
     {
         return $pointInTime->isBefore($this)
-            ? $this->since($pointInTime)->iterateBackward($by)
-            : $this->until($pointInTime)->iterate($by);
+            ? $this->since($pointInTime)->iterateBackward($by, Interval::closed())
+            : $this->until($pointInTime)->iterate($by, Interval::closed());
     }
 
     public function isAmbiguous() : bool

--- a/src/Aeon/Calendar/Gregorian/Interval.php
+++ b/src/Aeon/Calendar/Gregorian/Interval.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Calendar\Gregorian;
+
+use Aeon\Calendar\TimeUnit;
+
+/**
+ * @psalm-immutable
+ */
+final class Interval
+{
+    public const CLOSED = 0;
+
+    public const LEFT_OPEN = 1;
+
+    public const RIGHT_OPEN = 2;
+
+    public const OPEN = 4;
+
+    private int $type;
+
+    private function __construct(int $type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * A <= x <= B.
+     *
+     * @psalm-pure
+     */
+    public static function closed() : self
+    {
+        return new self(self::CLOSED);
+    }
+
+    /**
+     * A <= x < B.
+     *
+     * @psalm-pure
+     */
+    public static function rightOpen() : self
+    {
+        return new self(self::RIGHT_OPEN);
+    }
+
+    /**
+     * A < x <= B.
+     *
+     * @psalm-pure
+     */
+    public static function leftOpen() : self
+    {
+        return new self(self::LEFT_OPEN);
+    }
+
+    /**
+     * A < x < B.
+     *
+     * @psalm-pure
+     */
+    public static function open() : self
+    {
+        return new self(self::OPEN);
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     */
+    public function toDatePeriod(DateTime $left, TimeUnit $timeUnit, DateTime $right) : \DatePeriod
+    {
+        if ($this->type === self::CLOSED) {
+            return new \DatePeriod(
+                $left->toDateTimeImmutable(),
+                $timeUnit->toDateInterval(),
+                $right->add($timeUnit)->toDateTimeImmutable()
+            );
+        }
+
+        if ($this->type === self::LEFT_OPEN) {
+            return new \DatePeriod(
+                $left->add($timeUnit)->toDateTimeImmutable(),
+                $timeUnit->toDateInterval(),
+                $right->add($timeUnit)->toDateTimeImmutable()
+            );
+        }
+
+        if ($this->type === self::RIGHT_OPEN) {
+            return new \DatePeriod(
+                $left->toDateTimeImmutable(),
+                $timeUnit->toDateInterval(),
+                $right->toDateTimeImmutable()
+            );
+        }
+
+        return new \DatePeriod(
+            $left->add($timeUnit)->toDateTimeImmutable(),
+            $timeUnit->toDateInterval(),
+            $right->toDateTimeImmutable()
+        );
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     */
+    public function toDatePeriodBackward(DateTime $left, TimeUnit $timeUnit, DateTime $right) : \DatePeriod
+    {
+        if ($this->type === self::CLOSED) {
+            return new \DatePeriod(
+                $left->sub($timeUnit)->toDateTimeImmutable(),
+                $timeUnit->toDateInterval(),
+                $right->toDateTimeImmutable()
+            );
+        }
+
+        if ($this->type === self::LEFT_OPEN) {
+            return new \DatePeriod(
+                $left->toDateTimeImmutable(),
+                $timeUnit->toDateInterval(),
+                $right->toDateTimeImmutable()
+            );
+        }
+
+        if ($this->type === self::RIGHT_OPEN) {
+            return new \DatePeriod(
+                $left->sub($timeUnit)->toDateTimeImmutable(),
+                $timeUnit->toDateInterval(),
+                $right->sub($timeUnit)->toDateTimeImmutable()
+            );
+        }
+
+        return new \DatePeriod(
+            $left->toDateTimeImmutable(),
+            $timeUnit->toDateInterval(),
+            $right->sub($timeUnit)->toDateTimeImmutable()
+        );
+    }
+}

--- a/src/Aeon/Calendar/Gregorian/TimePeriod.php
+++ b/src/Aeon/Calendar/Gregorian/TimePeriod.php
@@ -61,7 +61,7 @@ final class TimePeriod
         return LeapSeconds::load()->findAllBetween($this);
     }
 
-    public function iterate(TimeUnit $timeUnit) : TimePeriods
+    public function iterate(TimeUnit $timeUnit, Interval $interval) : TimePeriods
     {
         return new TimePeriods(
             ...\array_map(
@@ -72,17 +72,13 @@ final class TimePeriod
                     );
                 },
                 \iterator_to_array(
-                    new \DatePeriod(
-                        $this->start->toDateTimeImmutable(),
-                        $timeUnit->toDateInterval(),
-                        $this->end->toDateTimeImmutable()
-                    )
+                    $interval->toDatePeriod($this->start, $timeUnit, $this->end)
                 )
             )
         );
     }
 
-    public function iterateBackward(TimeUnit $timeUnit) : TimePeriods
+    public function iterateBackward(TimeUnit $timeUnit, Interval $interval) : TimePeriods
     {
         return new TimePeriods(
             ...\array_map(
@@ -94,11 +90,7 @@ final class TimePeriod
                 },
                 \array_reverse(
                     \iterator_to_array(
-                        new \DatePeriod(
-                            $this->start->toDateTimeImmutable(),
-                            $timeUnit->toDateInterval(),
-                            $this->end->toDateTimeImmutable()
-                        )
+                        $interval->toDatePeriodBackward($this->start, $timeUnit, $this->end)
                     )
                 )
             )

--- a/tests/Aeon/Calendar/Tests/Functional/Gregorian/GregorianCalendarTest.php
+++ b/tests/Aeon/Calendar/Tests/Functional/Gregorian/GregorianCalendarTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Aeon\Calendar\Tests\Functional\Gregorian;
 
 use Aeon\Calendar\Gregorian\GregorianCalendar;
+use Aeon\Calendar\Gregorian\Interval;
 use Aeon\Calendar\Gregorian\TimePeriod;
 use Aeon\Calendar\Gregorian\TimeZone;
 use Aeon\Calendar\TimeUnit;
@@ -126,12 +127,12 @@ final class GregorianCalendarTest extends TestCase
             ->yesterday()
             ->midnight()
             ->until($calendar->tomorrow()->midnight())
-            ->iterate(TimeUnit::hour())
+            ->iterate(TimeUnit::hour(), Interval::closed())
             ->map(function (TimePeriod $timePeriod) use (&$iterations) {
                 return $timePeriod->start()->toDateTimeImmutable()->format('Y-m-d H:i:s');
             });
 
-        $this->assertCount(48, $timePeriods);
+        $this->assertCount(49, $timePeriods);
 
         $this->assertSame(
             (new \DateTimeImmutable('yesterday midnight'))->format('Y-m-d H:i:s'),
@@ -139,8 +140,8 @@ final class GregorianCalendarTest extends TestCase
         );
 
         $this->assertSame(
-            (new \DateTimeImmutable('tomorrow midnight'))->modify('-1 hour')->format('Y-m-d H:i:s'),
-            $timePeriods[47]
+            (new \DateTimeImmutable('tomorrow midnight'))->format('Y-m-d H:i:s'),
+            $timePeriods[48]
         );
     }
 
@@ -150,12 +151,12 @@ final class GregorianCalendarTest extends TestCase
             ->yesterday()
             ->midnight()
             ->until($calendar->tomorrow()->midnight())
-            ->iterate(TimeUnit::hour())
+            ->iterate(TimeUnit::hour(), Interval::closed())
             ->filter(function (TimePeriod $timePeriod) use (&$iterations) : bool {
                 return $timePeriod->start()->time()->hour() % 2 === 0;
             });
 
-        $this->assertCount(24, $timePeriods);
+        $this->assertCount(25, $timePeriods);
     }
 
     public function test_iterating_overt_time_backward() : void
@@ -164,7 +165,7 @@ final class GregorianCalendarTest extends TestCase
             ->yesterday()
             ->midnight()
             ->until($calendar->tomorrow()->midnight())
-            ->iterateBackward(TimeUnit::hour())
+            ->iterateBackward(TimeUnit::hour(), Interval::leftOpen())
             ->map(function (TimePeriod $interval) {
                 return $interval->start()->toDateTimeImmutable()->format('Y-m-d H:i:s');
             });

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Aeon\Calendar\Tests\Unit\Gregorian;
 
 use Aeon\Calendar\Gregorian\DateTime;
+use Aeon\Calendar\Gregorian\Interval;
 use Aeon\Calendar\Gregorian\TimePeriod;
 use Aeon\Calendar\TimeUnit;
 use PHPUnit\Framework\TestCase;
@@ -95,7 +96,7 @@ final class TimePeriodTest extends TestCase
             DateTime::fromString('2020-01-02 00:00:00.0000')
         );
 
-        $timePeriods = $period->iterate(TimeUnit::hour());
+        $timePeriods = $period->iterate(TimeUnit::hour(), Interval::rightOpen());
 
         $this->assertCount(24, $timePeriods);
 
@@ -121,7 +122,7 @@ final class TimePeriodTest extends TestCase
             DateTime::fromString('2020-01-02 00:00:00.0000')
         );
 
-        $timePeriods = $period->iterateBackward(TimeUnit::hour());
+        $timePeriods = $period->iterateBackward(TimeUnit::hour(), Interval::leftOpen());
 
         $this->assertCount(24, $timePeriods);
 
@@ -140,6 +141,102 @@ final class TimePeriodTest extends TestCase
         $this->assertSame(0, $timePeriods[23]->end()->time()->hour());
     }
 
+    public function test_iterating_by_days_interval_closed_both_ways() : void
+    {
+        $period = new TimePeriod(
+            DateTime::fromString('2020-01-01 00:00:00.0000'),
+            DateTime::fromString('2020-01-05 00:00:00.0000')
+        );
+
+        $timePeriods = $period->iterate(TimeUnit::day(), Interval::closed());
+        $timePeriodsBackward = $period->iterateBackward(TimeUnit::day(), Interval::closed());
+
+        $this->assertCount(5, $timePeriods);
+        $this->assertCount(5, $timePeriodsBackward);
+
+        $this->assertSame('2020-01-01', $timePeriods[0]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-02', $timePeriods[1]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-03', $timePeriods[2]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-04', $timePeriods[3]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-05', $timePeriods[4]->start()->format('Y-m-d'));
+
+        $this->assertSame('2020-01-05', $timePeriodsBackward[0]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-04', $timePeriodsBackward[1]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-03', $timePeriodsBackward[2]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-02', $timePeriodsBackward[3]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-01', $timePeriodsBackward[4]->start()->format('Y-m-d'));
+    }
+
+    public function test_iterating_by_days_interval_left_open_both_ways() : void
+    {
+        $period = new TimePeriod(
+            DateTime::fromString('2020-01-01 00:00:00.0000'),
+            DateTime::fromString('2020-01-05 00:00:00.0000')
+        );
+
+        $timePeriods = $period->iterate(TimeUnit::day(), Interval::leftOpen());
+        $timePeriodsBackward = $period->iterateBackward(TimeUnit::day(), Interval::leftOpen());
+
+        $this->assertCount(4, $timePeriods);
+        $this->assertCount(4, $timePeriodsBackward);
+
+        $this->assertSame('2020-01-02', $timePeriods[0]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-03', $timePeriods[1]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-04', $timePeriods[2]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-05', $timePeriods[3]->start()->format('Y-m-d'));
+
+        $this->assertSame('2020-01-05', $timePeriodsBackward[0]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-04', $timePeriodsBackward[1]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-03', $timePeriodsBackward[2]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-02', $timePeriodsBackward[3]->start()->format('Y-m-d'));
+    }
+
+    public function test_iterating_by_days_interval_right_open_both_ways() : void
+    {
+        $period = new TimePeriod(
+            DateTime::fromString('2020-01-01 00:00:00.0000'),
+            DateTime::fromString('2020-01-05 00:00:00.0000')
+        );
+
+        $timePeriods = $period->iterate(TimeUnit::day(), Interval::rightOpen());
+        $timePeriodsBackward = $period->iterateBackward(TimeUnit::day(), Interval::rightOpen());
+
+        $this->assertCount(4, $timePeriods);
+        $this->assertCount(4, $timePeriodsBackward);
+
+        $this->assertSame('2020-01-01', $timePeriods[0]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-02', $timePeriods[1]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-03', $timePeriods[2]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-04', $timePeriods[3]->start()->format('Y-m-d'));
+
+        $this->assertSame('2020-01-04', $timePeriodsBackward[0]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-03', $timePeriodsBackward[1]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-02', $timePeriodsBackward[2]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-01', $timePeriodsBackward[3]->start()->format('Y-m-d'));
+    }
+
+    public function test_iterating_by_days_interval_open_both_ways() : void
+    {
+        $period = new TimePeriod(
+            DateTime::fromString('2020-01-01 00:00:00.0000'),
+            DateTime::fromString('2020-01-05 00:00:00.0000')
+        );
+
+        $timePeriods = $period->iterate(TimeUnit::day(), Interval::open());
+        $timePeriodsBackward = $period->iterateBackward(TimeUnit::day(), Interval::open());
+
+        $this->assertCount(3, $timePeriods);
+        $this->assertCount(3, $timePeriodsBackward);
+
+        $this->assertSame('2020-01-02', $timePeriods[0]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-03', $timePeriods[1]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-04', $timePeriods[2]->start()->format('Y-m-d'));
+
+        $this->assertSame('2020-01-04', $timePeriodsBackward[0]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-03', $timePeriodsBackward[1]->start()->format('Y-m-d'));
+        $this->assertSame('2020-01-02', $timePeriodsBackward[2]->start()->format('Y-m-d'));
+    }
+
     public function test_iterating_through_day_by_2_days() : void
     {
         $period = new TimePeriod(
@@ -147,9 +244,9 @@ final class TimePeriodTest extends TestCase
             DateTime::fromString('2020-01-02 00:00:00.0000')
         );
 
-        $timePeriods = $period->iterate(TimeUnit::days(2));
+        $timePeriods = $period->iterate(TimeUnit::days(2), Interval::closed());
 
-        $this->assertCount(1, $timePeriods);
+        $this->assertCount(2, $timePeriods);
     }
 
     public function test_iterating_through_day_backward_by_2_days() : void
@@ -159,9 +256,9 @@ final class TimePeriodTest extends TestCase
             DateTime::fromString('2020-01-02 00:00:00.0000')
         );
 
-        $timePeriods = $period->iterateBackward(TimeUnit::days(2));
+        $timePeriods = $period->iterateBackward(TimeUnit::days(2), Interval::closed());
 
-        $this->assertCount(1, $timePeriods);
+        $this->assertCount(2, $timePeriods);
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodsTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Aeon\Calendar\Tests\Unit\Gregorian;
 
 use Aeon\Calendar\Gregorian\DateTime;
+use Aeon\Calendar\Gregorian\Interval;
 use Aeon\Calendar\Gregorian\TimePeriod;
 use Aeon\Calendar\Gregorian\TimePeriods;
 use Aeon\Calendar\TimeUnit;
@@ -16,7 +17,7 @@ final class TimePeriodsTest extends TestCase
     {
         $timePeriods = DateTime::fromString('2020-01-01 00:00:00.000000')
             ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
-            ->iterate(TimeUnit::minute());
+            ->iterate(TimeUnit::minute(), Interval::closed());
 
         $this->assertFalse(isset($timePeriods[5000]));
     }
@@ -25,7 +26,7 @@ final class TimePeriodsTest extends TestCase
     {
         $timePeriods = DateTime::fromString('2020-01-01 00:00:00.000000')
             ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
-            ->iterate(TimeUnit::minute());
+            ->iterate(TimeUnit::minute(), Interval::closed());
 
         $this->expectExceptionMessage('Aeon\Calendar\Gregorian\TimePeriods is immutable.');
 
@@ -39,7 +40,7 @@ final class TimePeriodsTest extends TestCase
     {
         $timePeriods = DateTime::fromString('2020-01-01 00:00:00.000000')
             ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
-            ->iterate(TimeUnit::minute());
+            ->iterate(TimeUnit::minute(), Interval::closed());
 
         $this->expectExceptionMessage('Aeon\Calendar\Gregorian\TimePeriods is immutable.');
 
@@ -51,7 +52,7 @@ final class TimePeriodsTest extends TestCase
         $counter = 0;
         DateTime::fromString('2020-01-01 00:00:00.000000')
             ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
-            ->iterate(TimeUnit::minute())
+            ->iterate(TimeUnit::minute(), Interval::rightOpen())
             ->each(function (TimePeriod $timePeriod) use (&$counter) : void {
                 /** @psalm-suppress MixedOperand */
                 $counter += 1;
@@ -64,7 +65,7 @@ final class TimePeriodsTest extends TestCase
     {
         $timePeriods = DateTime::fromString('2020-01-01 00:00:00.000000')
             ->until(DateTime::fromString('2020-01-01 01:00:00.000000'))
-            ->iterate(TimeUnit::minute());
+            ->iterate(TimeUnit::minute(), Interval::closed());
 
         $this->assertSame($timePeriods->all(), (array) $timePeriods->getIterator());
     }


### PR DESCRIPTION
So currently `TimePeriod::iterate` and `TimePeriod::iterateBackward` behavior might be a bit confusing for those who are not familiar with how PHP [\DatePeriod](https://www.php.net/manual/en/class.dateperiod.php) works. 

So the \DatePeriod can be considered as half-open interval, something like `A <= x < B` where A and B are two points in time. 
This behavior was even reported [here](https://bugs.php.net/bug.php?id=52015) however it wasn't considered as a bug of the \DatePeriod but more as a missing spot in the documentation (which makes sense because changing it would only bring an unnecessary BC break). 

Since the goal of Aeon is to provide better developer experience when working with Time I think it also makes sense to make this behavior more obvious and explicit.

Since now, (and that's not BC break yet because we are still in pre-release phase) `TimePeriod::iterate` and `TimePeriod::iterateBackward` methods will receive additional parameter, `Interval`. 
Interval can take 4 options, `closed`, `leftOpen`, `rightOpen`, `open`. 

**Old Behavior:**

```php
<?php

use Aeon\Calendar\Gregorian\DateTime;
use Aeon\Calendar\Gregorian\Interval;
use Aeon\Calendar\TimeUnit;

$timePeriods = DateTime::fromString('2020-01-01 00:00:00')
    ->until(DateTime::fromString('2020-01-05 00:00:00'))
    ->iterate(TimeUnit::day());

foreach ($timePeriods->all() as $period) {
    var_dump($period->start()->format('Y-m-d H:i:s'));
}

// 2020-01-01
// 2020-01-02
// 2020-01-03
// 2020-01-04
```

**New Behavior:**

```php
<?php

use Aeon\Calendar\Gregorian\DateTime;
use Aeon\Calendar\Gregorian\Interval;
use Aeon\Calendar\TimeUnit;

$timePeriods = DateTime::fromString('2020-01-01 00:00:00')
    ->until(DateTime::fromString('2020-01-05 00:00:00'))
    ->iterate(TimeUnit::day(), Interval::closed());

foreach ($timePeriods->all() as $period) {
    var_dump($period->start()->format('Y-m-d H:i:s'));
}

// 2020-01-01
// 2020-01-02
// 2020-01-03
// 2020-01-04
// 2020-01-05
```

This way developer gets full control over iterating over the time periods. 

Since now `DateTime::distance`, `DateTime::distanceUntil` and `DateTime::iterate` will use `Interval::closed()` by default.