### PR TITLE
TimeUnit - modulo 

### DIFF
--- a/src/Aeon/Calculator/BCMathCalculator.php
+++ b/src/Aeon/Calculator/BCMathCalculator.php
@@ -51,6 +51,26 @@ final class BCMathCalculator implements Calculator
         return \bcdiv($value, $divisor, $this->precision);
     }
 
+    /**
+     * @psalm-suppress InvalidNullableReturnType
+     * @psalm-suppress NullableReturnStatement
+     */
+    public function modulo(string $value, string $divisor) : string
+    {
+        if (!\is_numeric($value) || !\is_numeric($divisor)) {
+            throw new InvalidTypeException('Expected values to be numeric string');
+        }
+
+        if (\floatval($divisor) === \floatval('0')) {
+            throw new \LogicException("Divisor can't be 0");
+        }
+
+        /**
+         * @phpstan-ignore-next-line
+         */
+        return \bcmod($value, $divisor, $this->precision);
+    }
+
     public function multiply(string $value, string $multiplier) : string
     {
         if (!\is_numeric($value) || !\is_numeric($multiplier)) {

--- a/src/Aeon/Calculator/Calculator.php
+++ b/src/Aeon/Calculator/Calculator.php
@@ -11,6 +11,8 @@ interface Calculator
 {
     public function precision() : int;
 
+    public function modulo(string $value, string $divisor) : string;
+
     public function divide(string $value, string $divisor) : string;
 
     public function multiply(string $value, string $multiplier) : string;

--- a/src/Aeon/Calculator/PHPCalculator.php
+++ b/src/Aeon/Calculator/PHPCalculator.php
@@ -26,6 +26,11 @@ final class PHPCalculator implements Calculator
         return \number_format(\floatval($value) / \floatval($divisor), $this->precision, '.', '');
     }
 
+    public function modulo(string $value, string $divisor) : string
+    {
+        return \number_format(\fmod(\floatval($value), \floatval($divisor)), $this->precision, '.', '');
+    }
+
     public function multiply(string $value, string $multiplier) : string
     {
         return \number_format(\floatval($value) * \floatval($multiplier), $this->precision, '.', '');

--- a/src/Aeon/Calendar/TimeUnit.php
+++ b/src/Aeon/Calendar/TimeUnit.php
@@ -205,14 +205,14 @@ final class TimeUnit implements Unit
         return self::precise((float) (PreciseCalculator::initialize(self::PRECISION_MICROSECOND)->sub($this->inSecondsPrecise(), $timeUnit->inSecondsPrecise())));
     }
 
-    public function multiply(float $multiplier) : self
+    public function multiply(self $multiplier) : self
     {
-        return self::precise((float) (PreciseCalculator::initialize(self::PRECISION_MICROSECOND)->multiply($this->inSecondsPrecise(), (string) $multiplier)));
+        return self::precise((float) (PreciseCalculator::initialize(self::PRECISION_MICROSECOND)->multiply($this->inSecondsPrecise(), $multiplier->inSecondsPrecise())));
     }
 
-    public function divide(float $divider) : self
+    public function divide(self $divider) : self
     {
-        return self::precise((float) (PreciseCalculator::initialize(self::PRECISION_MICROSECOND)->divide($this->inSecondsPrecise(), (string) $divider)));
+        return self::precise((float) (PreciseCalculator::initialize(self::PRECISION_MICROSECOND)->divide($this->inSecondsPrecise(), $divider->inSecondsPrecise())));
     }
 
     public function isGreaterThan(self $timeUnit) : bool

--- a/src/Aeon/Calendar/TimeUnit.php
+++ b/src/Aeon/Calendar/TimeUnit.php
@@ -185,6 +185,11 @@ final class TimeUnit implements Unit
         return $interval;
     }
 
+    public function isZero() : bool
+    {
+        return $this->seconds === 0 && $this->microsecond === 0;
+    }
+
     public function isNegative() : bool
     {
         return $this->negative;
@@ -213,6 +218,11 @@ final class TimeUnit implements Unit
     public function divide(self $divider) : self
     {
         return self::precise((float) (PreciseCalculator::initialize(self::PRECISION_MICROSECOND)->divide($this->inSecondsPrecise(), $divider->inSecondsPrecise())));
+    }
+
+    public function modulo(self $divider) : self
+    {
+        return self::precise((float) (PreciseCalculator::initialize(self::PRECISION_MICROSECOND)->modulo($this->inSecondsPrecise(), $divider->inSecondsPrecise())));
     }
 
     public function isGreaterThan(self $timeUnit) : bool

--- a/tests/Aeon/Calculator/Tests/Unit/BCMathCalculatorTest.php
+++ b/tests/Aeon/Calculator/Tests/Unit/BCMathCalculatorTest.php
@@ -32,7 +32,7 @@ final class BCMathCalculatorTest extends TestCase
     }
 
     /**
-     * @dataProvider add_sub_provider
+     * @dataProvider sub_provider
      */
     public function test_sub(string $result, float $value, float $nextValue) : void
     {
@@ -42,7 +42,7 @@ final class BCMathCalculatorTest extends TestCase
     /**
      * @return \Generator<int, array{string, float, float}, mixed, void>
      */
-    public function add_sub_provider() : \Generator
+    public function sub_provider() : \Generator
     {
         yield ['1.000000', 2.0, 1.0];
         yield ['1.000000', 2, 1];
@@ -92,6 +92,29 @@ final class BCMathCalculatorTest extends TestCase
         yield ['1.010000', 0.000_101, 0.000_100];
         yield ['0.000000', 0.000_000, 0.000_000_1];
         yield ['4.900000', 0.000_000_49, 0.000_000_1];
+    }
+
+    /**
+     * @dataProvider modulo_provider
+     */
+    public function test_modulo(string $result, float $value, float $nextValue) : void
+    {
+        $this->assertSame($result, (new BCMathCalculator(6))->modulo(\number_format($value, 9), \number_format($nextValue, 9)));
+    }
+
+    /**
+     * @return \Generator<int, array{string, float, float}, mixed, void>
+     */
+    public function modulo_provider() : \Generator
+    {
+        yield ['0.000000', 1.0, 1.0];
+        yield ['0.000000', 2, 1];
+        yield ['1.000000', 7, 2];
+        yield ['1.999980', 7, 2.50001];
+        yield ['0.000000', 0.000_100, 0.000_100];
+        yield ['0.000001', 0.000_101, 0.000_100];
+        yield ['0.000000', 0.000_000, 0.000_000_1];
+        yield ['0.000000', 0.000_000_49, 0.000_000_1];
     }
 
     /**
@@ -205,6 +228,18 @@ final class BCMathCalculatorTest extends TestCase
         (new BCMathCalculator(6))->divide('10', 'invalid');
     }
 
+    public function test_invalid_value_in_modulo() : void
+    {
+        $this->expectException(InvalidTypeException::class);
+        (new BCMathCalculator(6))->modulo('test', '10');
+    }
+
+    public function test_invalid_division_in_modulo() : void
+    {
+        $this->expectException(InvalidTypeException::class);
+        (new BCMathCalculator(6))->modulo('10', 'invalid');
+    }
+
     public function test_invalid_value_in_multiply() : void
     {
         $this->expectException(InvalidTypeException::class);
@@ -306,5 +341,12 @@ final class BCMathCalculatorTest extends TestCase
         $this->expectException(\LogicException::class);
 
         (new BCMathCalculator(6))->divide('10', '0');
+    }
+
+    public function test_mod_by_zero() : void
+    {
+        $this->expectException(\LogicException::class);
+
+        (new BCMathCalculator(6))->modulo('10', '0');
     }
 }

--- a/tests/Aeon/Calculator/Tests/Unit/PHPCalculatorTest.php
+++ b/tests/Aeon/Calculator/Tests/Unit/PHPCalculatorTest.php
@@ -99,6 +99,29 @@ final class PHPCalculatorTest extends TestCase
     }
 
     /**
+     * @dataProvider modulo_provider
+     */
+    public function test_modulo(string $result, float $value, float $nextValue) : void
+    {
+        $this->assertSame($result, (new PHPCalculator(6))->modulo(\number_format($value, 9), \number_format($nextValue, 9)));
+    }
+
+    /**
+     * @return \Generator<int, array{string, float, float}, mixed, void>
+     */
+    public function modulo_provider() : \Generator
+    {
+        yield ['0.000000', 1.0, 1.0];
+        yield ['0.000000', 2, 1];
+        yield ['1.000000', 7, 2];
+        yield ['1.999980', 7, 2.50001];
+        yield ['0.000000', 0.000_100, 0.000_100];
+        yield ['0.000001', 0.000_101, 0.000_100];
+        yield ['0.000000', 0.000_000, 0.000_000_1];
+        yield ['0.000000', 0.000_000_49, 0.000_000_1];
+    }
+
+    /**
      * @dataProvider is_equal_data_provider
      */
     public function test_is_equal(bool $equal, float $value, float $nextValue) : void

--- a/tests/Aeon/Calendar/Tests/Unit/TimeUnitTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/TimeUnitTest.php
@@ -135,6 +135,12 @@ final class TimeUnitTest extends TestCase
         $this->assertSame(15, TimeUnit::minutes(135)->inTimeMinutes());
     }
 
+    public function test_is_zero() : void
+    {
+        $this->assertFalse(TimeUnit::second()->isZero());
+        $this->assertTrue(TimeUnit::seconds(0)->isZero());
+    }
+
     public function test_second() : void
     {
         $timeUnit = TimeUnit::second();
@@ -489,6 +495,25 @@ final class TimeUnitTest extends TestCase
         yield [TimeUnit::precise(1.00), TimeUnit::precise(2.00), TimeUnit::milliseconds(500)];
         yield [TimeUnit::precise(10.00), TimeUnit::precise(10.00), TimeUnit::seconds(1)];
         yield [TimeUnit::hours(1), TimeUnit::precise(60.00), TimeUnit::minutes(1)];
+    }
+
+    /**
+     * @dataProvider modulo_data_provider
+     */
+    public function test_modulo(TimeUnit $timeUnit, TimeUnit $multiplier, TimeUnit $expectedResult) : void
+    {
+        $this->assertSame($expectedResult->inSecondsPrecise(), $timeUnit->modulo($multiplier)->inSecondsPrecise());
+    }
+
+    /**
+     * @return \Generator<int, array{TimeUnit, float, TimeUnit}, mixed, void>
+     */
+    public function modulo_data_provider() : \Generator
+    {
+        yield [TimeUnit::precise(1.00), TimeUnit::precise(2.00), TimeUnit::second()];
+        yield [TimeUnit::precise(10.00), TimeUnit::precise(10.00), TimeUnit::seconds(0)];
+        yield [TimeUnit::hours(1), TimeUnit::precise(60.00), TimeUnit::seconds(0)];
+        yield [TimeUnit::hours(1), TimeUnit::minutes(37), TimeUnit::minutes(23)];
     }
 
     public function test_to_negative() : void

--- a/tests/Aeon/Calendar/Tests/Unit/TimeUnitTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/TimeUnitTest.php
@@ -458,7 +458,7 @@ final class TimeUnitTest extends TestCase
     /**
      * @dataProvider multiplication_data_provider
      */
-    public function test_multiplication(TimeUnit $timeUnit, float $multiplier, TimeUnit $expectedResult) : void
+    public function test_multiplication(TimeUnit $timeUnit, TimeUnit $multiplier, TimeUnit $expectedResult) : void
     {
         $this->assertSame($expectedResult->inSecondsPrecise(), $timeUnit->multiply($multiplier)->inSecondsPrecise());
     }
@@ -468,15 +468,15 @@ final class TimeUnitTest extends TestCase
      */
     public function multiplication_data_provider() : \Generator
     {
-        yield [TimeUnit::precise(1.00), 2.00, TimeUnit::precise(2.00)];
-        yield [TimeUnit::precise(1.00), 0.50, TimeUnit::precise(0.50)];
-        yield [TimeUnit::seconds(1), 0.50, TimeUnit::milliseconds(500)];
+        yield [TimeUnit::precise(1.00), TimeUnit::precise(2.00), TimeUnit::precise(2.00)];
+        yield [TimeUnit::precise(1.00), TimeUnit::precise(0.50), TimeUnit::precise(0.50)];
+        yield [TimeUnit::seconds(1), TimeUnit::precise(0.50), TimeUnit::milliseconds(500)];
     }
 
     /**
      * @dataProvider division_data_provider
      */
-    public function test_division(TimeUnit $timeUnit, float $multiplier, TimeUnit $expectedResult) : void
+    public function test_division(TimeUnit $timeUnit, TimeUnit $multiplier, TimeUnit $expectedResult) : void
     {
         $this->assertSame($expectedResult->inSecondsPrecise(), $timeUnit->divide($multiplier)->inSecondsPrecise());
     }
@@ -486,9 +486,9 @@ final class TimeUnitTest extends TestCase
      */
     public function division_data_provider() : \Generator
     {
-        yield [TimeUnit::precise(1.00), 2.00, TimeUnit::milliseconds(500)];
-        yield [TimeUnit::precise(10.00), 10.00, TimeUnit::seconds(1)];
-        yield [TimeUnit::hours(1), 60.00, TimeUnit::minutes(1)];
+        yield [TimeUnit::precise(1.00), TimeUnit::precise(2.00), TimeUnit::milliseconds(500)];
+        yield [TimeUnit::precise(10.00), TimeUnit::precise(10.00), TimeUnit::seconds(1)];
+        yield [TimeUnit::hours(1), TimeUnit::precise(60.00), TimeUnit::minutes(1)];
     }
 
     public function test_to_negative() : void


### PR DESCRIPTION
Added modulo into `Calendar` and `TimeUnit`. 
In order to unify all TimeUnit methods `divide` and `multiply` methods of `TimeUnit` now expects `TimeUnit $multiplier` and `TimeUnit $divider` instead of floats. 