### PR TITLE
Added possibility to find distance between two days without using Days collection

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,6 @@
 {
-  "image": "mcr.microsoft.com/vscode/devcontainers/php:7.4"
+  "image": "mcr.microsoft.com/vscode/devcontainers/php:7.4",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/zsh"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/vscode/devcontainers/php:7.4"
+}

--- a/src/Aeon/Calendar/Gregorian/Day.php
+++ b/src/Aeon/Calendar/Gregorian/Day.php
@@ -345,6 +345,11 @@ final class Day
         );
     }
 
+    public function distance(self $day) : TimeUnit
+    {
+        return (new TimePeriod($this->midnight(TimeZone::UTC()), $day->midnight(TimeZone::UTC())))->distance();
+    }
+
     public function quarter() : Quarter
     {
         return $this->year()->quarter((int) \ceil($this->month()->number() / 3));

--- a/tests/Aeon/Calculator/Tests/Unit/BCMathCalculatorTest.php
+++ b/tests/Aeon/Calculator/Tests/Unit/BCMathCalculatorTest.php
@@ -10,6 +10,13 @@ use PHPUnit\Framework\TestCase;
 
 final class BCMathCalculatorTest extends TestCase
 {
+    public function setUp() : void
+    {
+        if (!\extension_loaded('bcmath')) {
+            $this->markTestSkipped('Missing bcmath extension');
+        }
+    }
+
     /**
      * @dataProvider add_data_provider
      */

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
@@ -271,4 +271,9 @@ final class DayTest extends TestCase
         $this->assertSame(3, Day::fromString('2020-07-01')->quarter()->number());
         $this->assertSame(4, Day::fromString('2020-10-01')->quarter()->number());
     }
+
+    public function test_distance_between_two_days() : void
+    {
+        $this->assertSame(10, Day::fromString('2020-01-01')->distance(Day::fromString('2020-01-11'))->inDays());
+    }
 }


### PR DESCRIPTION
So far the only way to find the number of days between two days was to use `Day::iterate(Day $day) : Days`. 
This wasn't the most optimal way to calculate distance because iterate initialize creates a whole collection of Days immediately so when one wanted to calculate the distance of a year it was initializing collection of 365 days.  

This PR is adding `Day::distance(Day $day) : TimeUnit` method which internally use `TimePeriod` class 