### PR TITLE
DayValue Set collection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "psr-4": {
             "Aeon\\Calendar\\Tests\\": "tests/Aeon/Calendar/Tests/",
             "Aeon\\Calculator\\Tests\\": "tests/Aeon/Calculator/Tests/",
+            "Aeon\\Collection\\Tests\\": "tests/Aeon/Collection/Tests/",
             "Aeon\\Calendar\\Benchmark\\": "benchmark/Aeon/Calendar/Benchmark/"
         }
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,7 @@
         <testsuite name="unit">
             <directory suffix=".php">tests/Aeon/Calendar/Tests/Unit</directory>
             <directory suffix=".php">tests/Aeon/Calculator/Tests/Unit</directory>
+            <directory suffix=".php">tests/Aeon/Collection/Tests/Unit</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Aeon/Calendar/Gregorian/Day.php
+++ b/src/Aeon/Calendar/Gregorian/Day.php
@@ -76,6 +76,11 @@ final class Day
         ];
     }
 
+    public function toString() : string
+    {
+        return $this->format('Y-m-d');
+    }
+
     public function timeBetween(self $day) : TimeUnit
     {
         return TimeUnit::seconds(\abs(($this->toDateTimeImmutable()->getTimestamp() - $day->toDateTimeImmutable()->getTimestamp())));

--- a/src/Aeon/Calendar/Gregorian/Days.php
+++ b/src/Aeon/Calendar/Gregorian/Days.php
@@ -52,9 +52,11 @@ final class Days implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * @param callable(Day $day) : mixed $iterator
+     * @psalm-template MapResultType
      *
-     * @return array<mixed>
+     * @param callable(Day $day) : MapResultType $iterator
+     *
+     * @return array<MapResultType>
      */
     public function map(callable $iterator) : array
     {

--- a/src/Aeon/Calendar/Gregorian/Month.php
+++ b/src/Aeon/Calendar/Gregorian/Month.php
@@ -72,6 +72,11 @@ final class Month
         ];
     }
 
+    public function toString() : string
+    {
+        return $this->toDateTimeImmutable()->format('Y-m');
+    }
+
     public function previous() : self
     {
         return self::fromDateTime($this->toDateTimeImmutable()->modify('-1 month'));

--- a/src/Aeon/Calendar/Gregorian/Year.php
+++ b/src/Aeon/Calendar/Gregorian/Year.php
@@ -50,6 +50,11 @@ final class Year
         ];
     }
 
+    public function toString() : string
+    {
+        return (string) $this->year;
+    }
+
     public function january() : Month
     {
         return $this->months()->byNumber(1);

--- a/src/Aeon/Collection/DayValue.php
+++ b/src/Aeon/Collection/DayValue.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Collection;
+
+use Aeon\Calendar\Gregorian\Day;
+
+/**
+ * @psalm-immutable
+ */
+final class DayValue
+{
+    private Day $day;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @param mixed $value
+     */
+    public function __construct(Day $day, $value)
+    {
+        $this->day = $day;
+        $this->value = $value;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function createEmpty(Day $day) : self
+    {
+        return new self($day, null);
+    }
+
+    public function day() : Day
+    {
+        return $this->day;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+}

--- a/src/Aeon/Collection/DayValueSet.php
+++ b/src/Aeon/Collection/DayValueSet.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Collection;
+
+use Aeon\Calendar\Exception\InvalidArgumentException;
+use Aeon\Calendar\Gregorian\Day;
+use Aeon\Calendar\Gregorian\Days;
+use Aeon\Calendar\Gregorian\Interval;
+
+/**
+ * @psalm-immutable
+ */
+final class DayValueSet implements \Countable
+{
+    /**
+     * @var array<string, DayValue>
+     */
+    private array $dayValues;
+
+    public function __construct(DayValue ...$dayValues)
+    {
+        $indexedDayValues = [];
+
+        foreach ($dayValues as $dayValue) {
+            if (\array_key_exists($dayValue->day()->toString(), $indexedDayValues)) {
+                throw new InvalidArgumentException('Set does not allow duplicated days, day ' . $dayValue->day()->toString() . ' is duplicated');
+            }
+
+            $indexedDayValues[$dayValue->day()->toString()] = $dayValue;
+        }
+
+        $this->dayValues = $indexedDayValues;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function createEmpty(Day $start, Day $end) : self
+    {
+        return new self(
+            ...$start->until(
+                $end,
+                Interval::closed()
+            )->map(fn (Day $day) : DayValue => DayValue::createEmpty($day))
+        );
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed $value
+     */
+    public static function createWith(Day $start, Day $end, $value) : self
+    {
+        return new self(
+            ...$start->until(
+                $end,
+                Interval::closed()
+            )->map(fn (Day $day) : DayValue => new DayValue($day, $value))
+        );
+    }
+
+    /**
+     * @param mixed $value
+     * @psalm-suppress PossiblyNullReference
+     */
+    public function fillMissingWith($value) : self
+    {
+        if (!$this->count()) {
+            return $this;
+        }
+
+        $sortedDayValues = $this->sortAscending();
+
+        /* @phpstan-ignore-next-line  */
+        $daysRange = $sortedDayValues->first()->day()->until($sortedDayValues->last()->day(), Interval::closed());
+
+        foreach ($daysRange->all() as $nextDay) {
+            if (!$sortedDayValues->has($nextDay)) {
+                $sortedDayValues = $sortedDayValues->put(new DayValue($nextDay, $value));
+            }
+        }
+
+        return $sortedDayValues;
+    }
+
+    public function put(DayValue ...$dayValues) : self
+    {
+        $currentDayValues = $this->dayValues;
+
+        foreach ($dayValues as $dayValue) {
+            $currentDayValues[$dayValue->day()->toString()] = $dayValue;
+        }
+
+        return new self(...\array_values($currentDayValues));
+    }
+
+    public function remove(Day ...$days) : self
+    {
+        $currentDayValues = $this->dayValues;
+
+        foreach ($days as $day) {
+            if (\array_key_exists($day->toString(), $this->dayValues)) {
+                unset($currentDayValues[$day->toString()]);
+            }
+        }
+
+        return new self(...\array_values($currentDayValues));
+    }
+
+    public function has(Day $day) : bool
+    {
+        return \array_key_exists($day->toString(), $this->dayValues);
+    }
+
+    public function get(Day $day) : DayValue
+    {
+        if (!\array_key_exists($day->toString(), $this->dayValues)) {
+            throw new InvalidArgumentException('There is no value for day ' . $day->toString());
+        }
+
+        return $this->dayValues[$day->toString()];
+    }
+
+    public function first() : ?DayValue
+    {
+        if (!$this->count()) {
+            return null;
+        }
+
+        return \current($this->dayValues);
+    }
+
+    public function last() : ?DayValue
+    {
+        if (!$this->count()) {
+            return null;
+        }
+
+        /* @phpstan-ignore-next-line */
+        return \end($this->dayValues);
+    }
+
+    public function count() : int
+    {
+        return \count($this->dayValues);
+    }
+
+    /**
+     * @param callable(DayValue $dayValue) : bool $callback
+     */
+    public function filter(callable $callback) : self
+    {
+        return new self(...\array_values(\array_filter($this->dayValues, $callback)));
+    }
+
+    /**
+     * @param callable(DayValue $dayValue) : DayValue $callback
+     */
+    public function map(callable $callback) : self
+    {
+        /** @var array<DayValue> $dayValues */
+        $dayValues = \array_values(\array_map($callback, $this->dayValues));
+
+        return new self(...$dayValues);
+    }
+
+    /**
+     * @param callable(mixed $initial, DayValue $nextDayValue) : mixed $callback
+     * @param null|mixed $initial
+     *
+     * @return mixed
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        return \array_reduce($this->dayValues, $callback, $initial);
+    }
+
+    public function toDays() : Days
+    {
+        $days = [];
+
+        foreach ($this->dayValues as $dayValue) {
+            $days[] = $dayValue->day();
+        }
+
+        return new Days(...$days);
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment
+     *
+     * @return array<mixed>
+     */
+    public function values() : array
+    {
+        $values = [];
+
+        foreach ($this->dayValues as $dayValue) {
+            $values[] = $dayValue->value();
+        }
+
+        return $values;
+    }
+
+    public function sortAscending() : self
+    {
+        $values = $this->dayValues;
+
+        \uasort(
+            $values,
+            function (DayValue $dayValueA, DayValue $dayValueB) : int {
+                return $dayValueA->day()->toDateTimeImmutable() <=> $dayValueB->day()->toDateTimeImmutable();
+            }
+        );
+
+        return new self(...\array_values($values));
+    }
+
+    public function sortDescending() : self
+    {
+        $values = $this->dayValues;
+
+        \uasort(
+            $values,
+            function (DayValue $dayValueA, DayValue $dayValueB) : int {
+                return $dayValueB->day()->toDateTimeImmutable() <=> $dayValueA->day()->toDateTimeImmutable();
+            }
+        );
+
+        return new self(...\array_values($values));
+    }
+}

--- a/src/Aeon/Collection/DayValueSet.php
+++ b/src/Aeon/Collection/DayValueSet.php
@@ -232,4 +232,44 @@ final class DayValueSet implements \Countable
 
         return new self(...\array_values($values));
     }
+
+    /**
+     * A form of slice that returns the first n elements.
+     */
+    public function take(int $days) : self
+    {
+        if ($days < 0) {
+            throw new InvalidArgumentException('Take does not accept negative number of days');
+        }
+
+        return new self(...\array_values(\array_slice($this->dayValues, 0, $days)));
+    }
+
+    /**
+     * Return a sub-sequence of the set between the given offset and given number of days.
+     */
+    public function slice(int $offset, int $days) : self
+    {
+        if ($offset < 0) {
+            throw new InvalidArgumentException('Slice does not accept negative offset');
+        }
+
+        if ($days < 0) {
+            throw new InvalidArgumentException('Slice does not accept negative days');
+        }
+
+        return new self(...\array_values(\array_slice($this->dayValues, $offset, $days)));
+    }
+
+    /**
+     * A form of slice that returns all but the first n elements.
+     */
+    public function drop(int $offset) : self
+    {
+        if ($offset < 0) {
+            throw new InvalidArgumentException('Drop does not accept negative offset');
+        }
+
+        return new self(...\array_values(\array_slice($this->dayValues, $offset, \count($this->dayValues))));
+    }
 }

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
@@ -49,6 +49,14 @@ final class DayTest extends TestCase
         );
     }
 
+    public function test_to_string() : void
+    {
+        $this->assertSame(
+            '2020-01-01',
+            Day::fromString('2020-01-01')->toString()
+        );
+    }
+
     public function test_midnight() : void
     {
         $day = Day::fromString('2020-01-01');

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
@@ -51,6 +51,14 @@ final class MonthTest extends TestCase
         );
     }
 
+    public function test_to_string() : void
+    {
+        $this->assertSame(
+            '2020-01',
+            Month::fromString('2020-01-01')->toString()
+        );
+    }
+
     public function test_last_day_of_month() : void
     {
         $month = Month::fromString('2020-01-01');

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/YearTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/YearTest.php
@@ -72,6 +72,14 @@ final class YearTest extends TestCase
         );
     }
 
+    public function test_to_string() : void
+    {
+        $this->assertSame(
+            '2020',
+            Year::fromString('2020-01-01')->toString()
+        );
+    }
+
     public function test_map_days() : void
     {
         $days = (new Year(2020))->mapDays(fn (Day $day) : int => $day->number());

--- a/tests/Aeon/Collection/Tests/Unit/DayValueSetTest.php
+++ b/tests/Aeon/Collection/Tests/Unit/DayValueSetTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Collection\Tests\Unit;
+
+use Aeon\Calendar\Exception\InvalidArgumentException;
+use Aeon\Calendar\Gregorian\Day;
+use Aeon\Collection\DayValue;
+use Aeon\Collection\DayValueSet;
+use PHPUnit\Framework\TestCase;
+
+final class DayValueSetTest extends TestCase
+{
+    public function test_set_with_duplicated_days() : void
+    {
+        $this->expectExceptionMessage('Set does not allow duplicated days, day 2020-01-01 is duplicated');
+        $this->expectException(InvalidArgumentException::class);
+
+        new DayValueSet(
+            DayValue::createEmpty(Day::fromString('2020-01-01')),
+            DayValue::createEmpty(Day::fromString('2020-01-01'))
+        );
+    }
+
+    public function test_set_with_empty_values() : void
+    {
+        $set = DayValueSet::createEmpty(Day::fromString('2020-01-01'), Day::fromString('2020-01-10'));
+
+        $this->assertCount(10, $set);
+        $this->assertSame(
+            [null, null, null, null, null, null, null, null, null, null],
+            $set->values()
+        );
+    }
+
+    public function test_set_map() : void
+    {
+        $set = DayValueSet::createEmpty(Day::fromString('2020-01-01'), Day::fromString('2020-01-10'));
+        $set = $set->map(fn (DayValue $dayValue) : DayValue => new DayValue($dayValue->day(), $dayValue->day()->toString()));
+
+        $this->assertCount(10, $set);
+        $this->assertSame(
+            [
+                '2020-01-01',
+                '2020-01-02',
+                '2020-01-03',
+                '2020-01-04',
+                '2020-01-05',
+                '2020-01-06',
+                '2020-01-07',
+                '2020-01-08',
+                '2020-01-09',
+                '2020-01-10',
+            ],
+            $set->values()
+        );
+        $this->assertCount(10, $set->toDays());
+    }
+
+    public function test_set_filter() : void
+    {
+        $set = DayValueSet::createEmpty(Day::fromString('2020-01-01'), Day::fromString('2020-02-29'));
+        $filteredSet = $set->filter(fn (DayValue $dayValue) : bool => $dayValue->day()->month()->number() === 1);
+
+        $this->assertCount(31, $filteredSet);
+    }
+
+    public function test_set_reduce() : void
+    {
+        $set = DayValueSet::createWith(Day::fromString('2020-01-01'), Day::fromString('2020-02-29'), 1);
+        $numberOfDays = $set->reduce(fn (int $initial, DayValue $dayValue) : int => $initial + 1, 0);
+
+        $this->assertSame(60, $numberOfDays);
+    }
+
+    public function test_set_sort_ascending() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-10'), 100),
+            new DayValue(Day::fromString('2020-01-01'), 100),
+            new DayValue(Day::fromString('2020-01-07'), 100),
+            new DayValue(Day::fromString('2020-01-03'), 100),
+            new DayValue(Day::fromString('2020-01-05'), 100),
+            new DayValue(Day::fromString('2020-01-04'), 100),
+            new DayValue(Day::fromString('2020-01-08'), 100),
+            new DayValue(Day::fromString('2020-01-02'), 100),
+            new DayValue(Day::fromString('2020-01-06'), 100),
+            new DayValue(Day::fromString('2020-01-09'), 100),
+        );
+
+        $sortedSet = $set->sortAscending();
+
+        $this->assertSame(
+            [
+                '2020-01-01',
+                '2020-01-02',
+                '2020-01-03',
+                '2020-01-04',
+                '2020-01-05',
+                '2020-01-06',
+                '2020-01-07',
+                '2020-01-08',
+                '2020-01-09',
+                '2020-01-10',
+            ],
+            $sortedSet->toDays()->map(fn (Day $day) => $day->toString())
+        );
+        $this->assertSame('2020-01-01', $sortedSet->first()->day()->toString());
+        $this->assertSame('2020-01-10', $sortedSet->last()->day()->toString());
+    }
+
+    public function test_set_sort_descending() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-10'), 100),
+            new DayValue(Day::fromString('2020-01-01'), 100),
+            new DayValue(Day::fromString('2020-01-07'), 100),
+            new DayValue(Day::fromString('2020-01-03'), 100),
+            new DayValue(Day::fromString('2020-01-05'), 100),
+            new DayValue(Day::fromString('2020-01-04'), 100),
+            new DayValue(Day::fromString('2020-01-08'), 100),
+            new DayValue(Day::fromString('2020-01-02'), 100),
+            new DayValue(Day::fromString('2020-01-06'), 100),
+            new DayValue(Day::fromString('2020-01-09'), 100),
+        );
+
+        $sortedSet = $set->sortDescending();
+
+        $this->assertSame(
+            \array_reverse([
+                '2020-01-01',
+                '2020-01-02',
+                '2020-01-03',
+                '2020-01-04',
+                '2020-01-05',
+                '2020-01-06',
+                '2020-01-07',
+                '2020-01-08',
+                '2020-01-09',
+                '2020-01-10',
+            ]),
+            $sortedSet->toDays()->map(fn (Day $day) => $day->toString())
+        );
+    }
+
+    public function test_set_fill_missing_with() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-10'), 20),
+            new DayValue(Day::fromString('2020-01-01'), 20),
+        );
+
+        $set = $set->put(
+            new DayValue(Day::fromString('2020-01-03'), 100),
+            new DayValue(Day::fromString('2020-01-05'), 100),
+            new DayValue(Day::fromString('2020-01-04'), 100),
+        );
+
+        $set = $set->fillMissingWith(50)->sortAscending();
+
+        $this->assertSame(
+            [
+                0 => 20,
+                1 => 50,
+                2 => 100,
+                3 => 100,
+                4 => 100,
+                5 => 50,
+                6 => 50,
+                7 => 50,
+                8 => 50,
+                9 => 20,
+            ],
+            $set->values()
+        );
+    }
+
+    public function test_set_remove() : void
+    {
+        $set = DayValueSet::createEmpty(Day::fromString('2020-01-01'), Day::fromString('2020-01-31'));
+        $set = $set->remove(Day::fromString('2020-01-10'));
+
+        $this->assertCount(30, $set);
+
+        $this->assertFalse($set->has(Day::fromString('2020-01-10')));
+    }
+
+    public function test_get_non_existing_day() : void
+    {
+        $set = DayValueSet::createEmpty(Day::fromString('2020-01-01'), Day::fromString('2020-01-31'));
+        $set = $set->remove(Day::fromString('2020-01-10'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('There is no value for day 2020-01-10');
+
+        $this->assertFalse($set->get(Day::fromString('2020-01-10')));
+    }
+}

--- a/tests/Aeon/Collection/Tests/Unit/DayValueSetTest.php
+++ b/tests/Aeon/Collection/Tests/Unit/DayValueSetTest.php
@@ -196,4 +196,223 @@ final class DayValueSetTest extends TestCase
 
         $this->assertFalse($set->get(Day::fromString('2020-01-10')));
     }
+
+    public function test_take() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(
+                new DayValue(Day::fromString('2020-01-01'), 10),
+                new DayValue(Day::fromString('2020-01-02'), 20),
+            ),
+            $set->take(2)
+        );
+    }
+
+    public function test_take_more_than_available() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(
+                new DayValue(Day::fromString('2020-01-01'), 10),
+                new DayValue(Day::fromString('2020-01-02'), 20),
+                new DayValue(Day::fromString('2020-01-03'), 30),
+                new DayValue(Day::fromString('2020-01-04'), 40),
+            ),
+            $set->take(6)
+        );
+    }
+
+    public function test_take_negative_days() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Take does not accept negative number of days');
+
+        $set->take(-1);
+    }
+
+    public function test_take_zero_days() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(),
+            $set->take(0)
+        );
+    }
+
+    public function test_slice() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(
+                new DayValue(Day::fromString('2020-01-02'), 20),
+                new DayValue(Day::fromString('2020-01-03'), 30),
+            ),
+            $set->slice(1, 2)
+        );
+    }
+
+    public function test_slice_more_than_available() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(
+                new DayValue(Day::fromString('2020-01-01'), 10),
+                new DayValue(Day::fromString('2020-01-02'), 20),
+                new DayValue(Day::fromString('2020-01-03'), 30),
+                new DayValue(Day::fromString('2020-01-04'), 40),
+            ),
+            $set->slice(0, 10)
+        );
+    }
+
+    public function test_slice_with_zero_offset_and_zero_days() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(),
+            $set->slice(0, 0)
+        );
+    }
+
+    public function test_slice_negative_days() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Slice does not accept negative days');
+
+        $set->slice(0, -1);
+    }
+
+    public function test_slice_negative_offset() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Slice does not accept negative offset');
+
+        $set->slice(-1, 5);
+    }
+
+    public function test_drop() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(
+                new DayValue(Day::fromString('2020-01-03'), 30),
+                new DayValue(Day::fromString('2020-01-04'), 40),
+            ),
+            $set->drop(2)
+        );
+    }
+
+    public function test_drop_zero_offset() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(
+                new DayValue(Day::fromString('2020-01-01'), 10),
+                new DayValue(Day::fromString('2020-01-02'), 20),
+                new DayValue(Day::fromString('2020-01-03'), 30),
+                new DayValue(Day::fromString('2020-01-04'), 40),
+            ),
+            $set->drop(0)
+        );
+    }
+
+    public function test_drop_negative_offset() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Drop does not accept negative offset');
+
+        $set->drop(-1);
+    }
+
+    public function test_drop_more_than_available() : void
+    {
+        $set = new DayValueSet(
+            new DayValue(Day::fromString('2020-01-01'), 10),
+            new DayValue(Day::fromString('2020-01-02'), 20),
+            new DayValue(Day::fromString('2020-01-03'), 30),
+            new DayValue(Day::fromString('2020-01-04'), 40),
+        );
+
+        $this->assertEquals(
+            new DayValueSet(),
+            $set->drop(10)
+        );
+    }
 }


### PR DESCRIPTION
The goal of this feature is to simplify working with set's of days with assigned values. 
Following example should explain everything. 

```php
<?php

use Aeon\Calendar\Gregorian\Day;
use Aeon\Collection\DayValue;
use Aeon\Collection\DayValueSet;

require_once __DIR__ . '/../vendor/autoload.php';

$initialSet = DayValueSet::createWith(
    Day::fromString('-10 days'),
    Day::fromString('yesterday'),
    $initialValue = 0
);

// Fetch those values from database or any other source
$sales = [
    new DayValue(Day::fromString('-1 day'), 100),
    new DayValue(Day::fromString('-2 day'), 150),
    new DayValue(Day::fromString('-3 day'), 125),
    // Day 4 business was closed, no sales
    new DayValue(Day::fromString('-5 day'), 180),
    new DayValue(Day::fromString('-6 day'), 100),
    new DayValue(Day::fromString('-7 day'), 108),
    new DayValue(Day::fromString('-8 day'), 100),
    new DayValue(Day::fromString('-9 day'), 150),
    new DayValue(Day::fromString('-10 day'), 130),
];

$salesSet = $initialSet->put(...$sales)->sortDescending();
$totalSales = $salesSet->reduce(fn(int $total, DayValue $dayValue) : int => $dayValue->value() + $total, 0);

$T10AvgSales = floor($totalSales / $salesSet->count());

/**

2020-10-08 - 100
2020-10-07 - 150
2020-10-06 - 125
2020-10-05 - 0
2020-10-04 - 180
2020-10-03 - 100
2020-10-02 - 108
2020-10-01 - 100
2020-09-30 - 150
2020-09-29 - 130
---
AVG Sales: 114

*/
```