### PR TITLE
DateTime object will set UTC timezone when zero offset is provided

### DIFF
--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -28,7 +28,9 @@ final class DateTime
     private int $unixTimestamp;
 
     /**
-     * TimeZone is optional, if not provided it will be set to UTC.
+     * TimeZone is optional, if not provided it will be set to UTC as long, as TimeOffset is zero,
+     * or remain null otherwise.
+     *
      * DateTime always has TimeOffset but when not provided it's calculated from offset and when
      * offset is not provided is set to UTC.
      */
@@ -60,6 +62,8 @@ final class DateTime
 
         if ($this->timeZone !== null) {
             $this->timeOffset = $this->timeZone->timeOffset($this);
+        } elseif ($this->timeOffset->isUTC()) {
+            $this->timeZone = TimeZone::UTC();
         }
     }
 

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -710,6 +710,21 @@ final class DateTimeTest extends TestCase
         $this->assertSame('UTC', $timeZone->name());
     }
 
+    public function test_timezone_when_not_explicitly_provided_with_zero_offset_explicitly_provided() : void
+    {
+        $timeZone = DateTime::fromString('2020-03-29 00:00:00+00:00')->timeZone();
+
+        $this->assertInstanceOf(TimeZone::class, $timeZone);
+        $this->assertSame('UTC', $timeZone->name());
+    }
+
+    public function test_timezone_when_not_explicitly_provided_with_non_zero_offset_explicitly_provided() : void
+    {
+        $timeZone = DateTime::fromString('2020-03-29 00:00:00+01:00')->timeZone();
+
+        $this->assertNull($timeZone);
+    }
+
     public function test_time_offset_when_not_explicitly_provided() : void
     {
         $this->assertSame('+00:00', DateTime::fromString('2020-03-29 00:00:00')->timeOffset()->toString());


### PR DESCRIPTION
As \Aeon\Calendar\Gregorian\DateTime constructor's description says, if TimeZone parameter is not provided, it will be set to UTC value as long, as it is possible. 

Doing so, we will have symmetric \Aeon\Calendar\Gregorian\DateTime objects after calling:
`DateTime::fromString('2020-07-13 12:00')` 
and
`DateTime::fromString('2020-07-13 12:00+00:00')`