### PR TITLE
Make sure all DateTime constructors create the same instance

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -41,7 +41,8 @@
     "InstanceOf_": {
       "ignore": [
         "Aeon\\Calculator\\PreciseCalculator::initialize",
-        "Aeon\\Calendar\\Gregorian\\LeapSeconds::load"
+        "Aeon\\Calendar\\Gregorian\\LeapSeconds::load",
+        "Aeon\\Calendar\\Gregorian\\DateTime::toDateTimeImmutable"
       ]
     }
   },

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -42,6 +42,10 @@ final class DateTime
         if ($this->timeZone !== null) {
             $this->timeOffset = $this->timeZone->timeOffset($this);
         }
+
+        if ($this->timeZone === null && $this->timeOffset->isUTC()) {
+            $this->timeZone = TimeZone::UTC();
+        }
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -91,6 +91,18 @@ final class DateTimeTest extends TestCase
         );
     }
 
+    public function test_create_without_timezone() : void
+    {
+        $this->assertSame(
+            '+00:00',
+            (new DateTime(new Day(new Month(new Year(2020), 1), 1), new Time(0, 0, 0)))->timeOffset()->toString()
+        );
+        $this->assertSame(
+            'UTC',
+            (new DateTime(new Day(new Month(new Year(2020), 1), 1), new Time(0, 0, 0)))->timeZone()->name()
+        );
+    }
+
     public function test_create_from_string_without_offset_and_timezone() : void
     {
         $this->assertSame(
@@ -143,14 +155,14 @@ final class DateTimeTest extends TestCase
         $dateTimeCreate = DateTime::create(2020, 01, 01, 00, 00, 00);
         $dateTime = new DateTime(new Day(new Month(new Year(2020), 01), 01), new Time(00, 00, 00));
 
-        $this->assertObjectEquals($dateTime, $dateTimeFromString, 'isEqual');
-        $this->assertObjectEquals($dateTime, $dateTimeFromTimestamp, 'isEqual');
-        $this->assertObjectEquals($dateTime, $dateTimeCreate, 'isEqual');
+        $this->assertTrue($dateTime->isEqual($dateTimeFromString));
+        $this->assertTrue($dateTime->isEqual($dateTimeFromTimestamp));
+        $this->assertTrue($dateTime->isEqual($dateTimeCreate));
 
-        $this->assertObjectEquals($dateTimeFromString, $dateTimeCreate, 'isEqual');
-        $this->assertObjectEquals($dateTimeFromString, $dateTimeFromTimestamp, 'isEqual');
+        $this->assertTrue($dateTimeFromString->isEqual($dateTimeCreate));
+        $this->assertTrue($dateTimeFromString->isEqual($dateTimeFromTimestamp));
 
-        $this->assertObjectEquals($dateTimeFromTimestamp, $dateTimeCreate, 'isEqual');
+        $this->assertTrue($dateTimeFromTimestamp->isEqual($dateTimeCreate));
     }
 
     public function test_compare_source_datetime_immutable_with_converted_one() : void

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -51,6 +51,22 @@ final class DateTimeTest extends TestCase
         yield ['2020-10-25 01:30:00+02:00', DateTime::fromString('2020-10-25 01:30:00 Europe/Warsaw'), 'Y-m-d H:i:sP'];
     }
 
+    public function test_debug_info() : void
+    {
+        $dateTime = DateTime::fromString('2020-01-01 00:00:00 America/Los_Angeles');
+
+        $this->assertSame(
+            [
+                'datetime' => $dateTime->toISO8601(),
+                'day' => $dateTime->day(),
+                'time' => $dateTime->time(),
+                'offset' => $dateTime->timeOffset(),
+                'timezone' => $dateTime->timeZone(),
+            ],
+            $dateTime->__debugInfo()
+        );
+    }
+
     public function test_create_without_timezone_and_time_offset() : void
     {
         $this->assertSame(
@@ -73,6 +89,95 @@ final class DateTimeTest extends TestCase
             '-03:00',
             (new DateTime(new Day(new Month(new Year(2020), 1), 1), new Time(0, 0, 0), TimeZone::americaFortaleza()))->timeOffset()->toString()
         );
+    }
+
+    public function test_create_from_string_without_offset_and_timezone() : void
+    {
+        $this->assertSame(
+            '+00:00',
+            DateTime::fromString('2020-01-01 00:00:00')->timeOffset()->toString()
+        );
+        $this->assertSame(
+            'UTC',
+            DateTime::fromString('2020-01-01 00:00:00')->timeZone()->name()
+        );
+    }
+
+    public function test_create_from_string_with_default_system_timezone() : void
+    {
+        \date_default_timezone_set('Europe/Warsaw');
+
+        $this->assertSame(
+            '+00:00',
+            DateTime::fromString('2020-01-01 00:00:00')->timeOffset()->toString()
+        );
+        $this->assertSame(
+            'UTC',
+            DateTime::fromString('2020-01-01 00:00:00')->timeZone()->name()
+        );
+        $this->assertSame('Europe/Warsaw', \date_default_timezone_get());
+    }
+
+    public function test_create_from_timestamp_with_default_system_timezone() : void
+    {
+        \date_default_timezone_set('Europe/Warsaw');
+
+        $this->assertSame(
+            '+00:00',
+            DateTime::fromTimestampUnix(1577836800)->timeOffset()->toString()
+        );
+        $this->assertSame(
+            'UTC',
+            DateTime::fromTimestampUnix(1577836800)->timeZone()->name()
+        );
+
+        $this->assertSame('Europe/Warsaw', \date_default_timezone_get());
+    }
+
+    public function test_compare_objects_create_through_different_constructors() : void
+    {
+        \date_default_timezone_set('Europe/Warsaw');
+
+        $dateTimeFromString = DateTime::fromString('2020-01-01 00:00:00');
+        $dateTimeFromTimestamp = DateTime::fromTimestampUnix(1577836800);
+        $dateTimeCreate = DateTime::create(2020, 01, 01, 00, 00, 00);
+        $dateTime = new DateTime(new Day(new Month(new Year(2020), 01), 01), new Time(00, 00, 00));
+
+        $this->assertObjectEquals($dateTime, $dateTimeFromString, 'isEqual');
+        $this->assertObjectEquals($dateTime, $dateTimeFromTimestamp, 'isEqual');
+        $this->assertObjectEquals($dateTime, $dateTimeCreate, 'isEqual');
+
+        $this->assertObjectEquals($dateTimeFromString, $dateTimeCreate, 'isEqual');
+        $this->assertObjectEquals($dateTimeFromString, $dateTimeFromTimestamp, 'isEqual');
+
+        $this->assertObjectEquals($dateTimeFromTimestamp, $dateTimeCreate, 'isEqual');
+    }
+
+    public function test_compare_source_datetime_immutable_with_converted_one() : void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable('2020-01-01 00:00:00');
+
+        $dateTime = DateTime::fromDateTime($dateTimeImmutable);
+
+        $this->assertEquals($dateTimeImmutable, $dateTime->toDateTimeImmutable());
+    }
+
+    public function test_compare_source_datetime_immutable_with_timezone_with_converted_one() : void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable('2020-01-01 00:00:00 America/Los_Angeles');
+
+        $dateTime = DateTime::fromDateTime($dateTimeImmutable);
+
+        $this->assertEquals($dateTimeImmutable, $dateTime->toDateTimeImmutable());
+    }
+
+    public function test_compare_source_from_string_with_timezone_with_converted_one() : void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable('2020-01-01 00:00:00 America/Los_Angeles');
+
+        $dateTime = DateTime::fromString('2020-01-01 00:00:00 America/Los_Angeles');
+
+        $this->assertEquals($dateTimeImmutable, $dateTime->toDateTimeImmutable());
     }
 
     public function test_create_with_timezone_and_time_offset() : void


### PR DESCRIPTION
It's another iteration of DateTime constructor improvements, hopefully, the last one. 
Delaying DateTimeImmutable initialization should improve the performance and it also solves the problem of taking different timeoffset and timezone than the one passed through the constructor. 

It's an alternative approach to #71 