### PR TITLE
Remove function trailing commas

### DIFF
--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DaysTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DaysTest.php
@@ -15,7 +15,7 @@ final class DaysTest extends TestCase
         $days = new Days(
             Day::fromString('2002-01-01'),
             Day::fromString('2002-01-02'),
-            Day::fromString('2002-01-03'),
+            Day::fromString('2002-01-03')
         );
 
         $this->assertTrue(isset($days[0]));
@@ -28,7 +28,7 @@ final class DaysTest extends TestCase
         $days = new Days(
             Day::fromString('2002-01-01'),
             Day::fromString('2002-01-02'),
-            Day::fromString('2002-01-03'),
+            Day::fromString('2002-01-03')
         );
 
         $this->assertSame(
@@ -44,7 +44,7 @@ final class DaysTest extends TestCase
         $days = new Days(
             Day::fromString('2002-01-01'),
             Day::fromString('2002-01-02'),
-            Day::fromString('2002-01-03'),
+            Day::fromString('2002-01-03')
         );
 
         $this->assertEquals(

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthsTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthsTest.php
@@ -17,7 +17,7 @@ final class MonthsTest extends TestCase
         $months = new Months(
             Month::fromString('2002-01-01'),
             Month::fromString('2002-02-02'),
-            Month::fromString('2002-03-03'),
+            Month::fromString('2002-03-03')
         );
 
         $this->assertTrue(isset($months[0]));
@@ -31,7 +31,7 @@ final class MonthsTest extends TestCase
         $days = new Months(
             Month::fromString('2002-01-01'),
             Month::fromString('2002-02-02'),
-            Month::fromString('2002-03-03'),
+            Month::fromString('2002-03-03')
         );
 
         $this->assertSame(
@@ -47,7 +47,7 @@ final class MonthsTest extends TestCase
         $months = new Months(
             Month::fromString('2002-01-01'),
             Month::fromString('2002-02-02'),
-            Month::fromString('2002-03-03'),
+            Month::fromString('2002-03-03')
         );
 
         $this->assertEquals(

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodTest.php
@@ -62,7 +62,7 @@ final class TimePeriodTest extends TestCase
     {
         $period = new TimePeriod(
             DateTime::fromString('1969-01-01 01:00:00.0000'),
-            DateTime::fromString('1969-01-01 00:00:00.0000'),
+            DateTime::fromString('1969-01-01 00:00:00.0000')
         );
 
         $this->assertSame(-3600, $period->distance()->inSeconds());

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodsTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodsTest.php
@@ -118,7 +118,7 @@ final class TimePeriodsTest extends TestCase
             new TimePeriod(DateTime::fromString('2020-01-10 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000000')),
             new TimePeriod(DateTime::fromString('2020-01-01 00:00:00.000000'), DateTime::fromString('2020-01-02 00:00:00.000000')),
             new TimePeriod(DateTime::fromString('2020-01-05 00:00:00.000000'), DateTime::fromString('2020-01-07 00:00:00.000000')),
-            new TimePeriod(DateTime::fromString('2020-01-03 00:00:00.000000'), DateTime::fromString('2020-01-06 00:00:00.000000')),
+            new TimePeriod(DateTime::fromString('2020-01-03 00:00:00.000000'), DateTime::fromString('2020-01-06 00:00:00.000000'))
         );
 
         $this->assertCount(
@@ -134,7 +134,7 @@ final class TimePeriodsTest extends TestCase
             new TimePeriod(DateTime::fromString('2020-01-10 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000000')),
             new TimePeriod(DateTime::fromString('2020-01-01 00:00:00.000000'), DateTime::fromString('2020-01-02 00:00:00.000000')),
             new TimePeriod(DateTime::fromString('2020-01-05 00:00:00.000000'), DateTime::fromString('2020-01-07 00:00:00.000000')),
-            new TimePeriod(DateTime::fromString('2020-01-03 00:00:00.000000'), DateTime::fromString('2020-01-06 00:00:00.000000')),
+            new TimePeriod(DateTime::fromString('2020-01-03 00:00:00.000000'), DateTime::fromString('2020-01-06 00:00:00.000000'))
         );
 
         $this->assertCount(

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/YearsTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/YearsTest.php
@@ -15,7 +15,7 @@ final class YearsTest extends TestCase
         $years = new Years(
             Year::fromString('2000-01-01'),
             Year::fromString('2001-02-02'),
-            Year::fromString('2002-03-03'),
+            Year::fromString('2002-03-03')
         );
 
         $this->assertTrue(isset($years[0]));
@@ -29,7 +29,7 @@ final class YearsTest extends TestCase
         $yeras = new Years(
             Year::fromString('2000-01-01'),
             Year::fromString('2001-02-02'),
-            Year::fromString('2002-03-03'),
+            Year::fromString('2002-03-03')
         );
 
         $this->assertSame(
@@ -45,7 +45,7 @@ final class YearsTest extends TestCase
         $years = new Years(
             Year::fromString('2000-01-01'),
             Year::fromString('2001-02-02'),
-            Year::fromString('2002-03-03'),
+            Year::fromString('2002-03-03')
         );
 
         $this->assertEquals(

--- a/tests/Aeon/Collection/Tests/Unit/DayValueSetTest.php
+++ b/tests/Aeon/Collection/Tests/Unit/DayValueSetTest.php
@@ -86,7 +86,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-08'), 100),
             new DayValue(Day::fromString('2020-01-02'), 100),
             new DayValue(Day::fromString('2020-01-06'), 100),
-            new DayValue(Day::fromString('2020-01-09'), 100),
+            new DayValue(Day::fromString('2020-01-09'), 100)
         );
 
         $sortedSet = $set->sortAscending();
@@ -122,7 +122,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-08'), 100),
             new DayValue(Day::fromString('2020-01-02'), 100),
             new DayValue(Day::fromString('2020-01-06'), 100),
-            new DayValue(Day::fromString('2020-01-09'), 100),
+            new DayValue(Day::fromString('2020-01-09'), 100)
         );
 
         $sortedSet = $set->sortDescending();
@@ -148,13 +148,13 @@ final class DayValueSetTest extends TestCase
     {
         $set = new DayValueSet(
             new DayValue(Day::fromString('2020-01-10'), 20),
-            new DayValue(Day::fromString('2020-01-01'), 20),
+            new DayValue(Day::fromString('2020-01-01'), 20)
         );
 
         $set = $set->put(
             new DayValue(Day::fromString('2020-01-03'), 100),
             new DayValue(Day::fromString('2020-01-05'), 100),
-            new DayValue(Day::fromString('2020-01-04'), 100),
+            new DayValue(Day::fromString('2020-01-04'), 100)
         );
 
         $set = $set->fillMissingWith(50)->sortAscending();
@@ -203,7 +203,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(
@@ -221,7 +221,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(
@@ -241,7 +241,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->expectException(InvalidArgumentException::class);
@@ -256,7 +256,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(
@@ -271,7 +271,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(
@@ -289,7 +289,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(
@@ -309,7 +309,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(
@@ -324,7 +324,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->expectException(InvalidArgumentException::class);
@@ -339,7 +339,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->expectException(InvalidArgumentException::class);
@@ -354,7 +354,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(
@@ -372,7 +372,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(
@@ -392,7 +392,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->expectException(InvalidArgumentException::class);
@@ -407,7 +407,7 @@ final class DayValueSetTest extends TestCase
             new DayValue(Day::fromString('2020-01-01'), 10),
             new DayValue(Day::fromString('2020-01-02'), 20),
             new DayValue(Day::fromString('2020-01-03'), 30),
-            new DayValue(Day::fromString('2020-01-04'), 40),
+            new DayValue(Day::fromString('2020-01-04'), 40)
         );
 
         $this->assertEquals(


### PR DESCRIPTION
Since phpcsfixer (and any other tool that I know) is not capable yet to remove/add function argument trailing commas for now it needs to be removed manually. 