### PR TITLE
Reverted support for relative dates into toString methods

### DIFF
--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -70,26 +70,33 @@ final class DateTime
      */
     public static function fromString(string $date) : self
     {
-        $dateParts = \date_parse($date);
+        $dateNormalized = \trim(\strtolower($date));
+        $dateTimeParts = \date_parse($date);
 
-        if (!\is_array($dateParts)) {
+        if (!\is_array($dateTimeParts)) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid date time format.");
         }
 
-        if ($dateParts['error_count'] > 0) {
+        if ($dateTimeParts['error_count'] > 0) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid date time format.");
         }
 
-        if (!\is_int($dateParts['year']) || !\is_int($dateParts['month']) || !\is_int($dateParts['day'])) {
+        if (isset($dateTimeParts['relative']) || \in_array($dateNormalized, ['midnight', 'noon', 'now', 'today'], true)) {
+            $currentPHPTimeZone = \date_default_timezone_get();
+            \date_default_timezone_set('UTC');
+            $dateTime = self::fromDateTime(new \DateTimeImmutable($date));
+            \date_default_timezone_set($currentPHPTimeZone);
+
+            return $dateTime;
+        }
+
+        if (!\is_int($dateTimeParts['year']) || !\is_int($dateTimeParts['month']) || !\is_int($dateTimeParts['day'])) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid date time format.");
         }
 
         $currentPHPTimeZone = \date_default_timezone_get();
-
         \date_default_timezone_set('UTC');
-
         $dateTime = self::fromDateTime(new \DateTimeImmutable($date));
-
         \date_default_timezone_set($currentPHPTimeZone);
 
         return $dateTime;

--- a/src/Aeon/Calendar/Gregorian/Day.php
+++ b/src/Aeon/Calendar/Gregorian/Day.php
@@ -61,6 +61,7 @@ final class Day
      */
     public static function fromString(string $date) : self
     {
+        $dateNormalized = \trim(\strtolower($date));
         $dateParts = \date_parse($date);
 
         if (!\is_array($dateParts)) {
@@ -71,12 +72,12 @@ final class Day
             throw new InvalidArgumentException("Value \"{$date}\" is not valid day format.");
         }
 
-        if (!\is_int($dateParts['year']) || !\is_int($dateParts['month']) || !\is_int($dateParts['day'])) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid day format.");
+        if (isset($dateParts['relative']) || \in_array($dateNormalized, ['midnight', 'noon', 'now', 'today'], true)) {
+            return self::fromDateTime(new \DateTimeImmutable($date));
         }
 
-        if (isset($dateParts['relative'])) {
-            return self::fromDateTime(new \DateTimeImmutable($date));
+        if (!\is_int($dateParts['year']) || !\is_int($dateParts['month']) || !\is_int($dateParts['day'])) {
+            throw new InvalidArgumentException("Value \"{$date}\" is not valid day format.");
         }
 
         return new self(new Month(new Year($dateParts['year']), $dateParts['month']), $dateParts['day']);

--- a/src/Aeon/Calendar/Gregorian/Month.php
+++ b/src/Aeon/Calendar/Gregorian/Month.php
@@ -58,6 +58,7 @@ final class Month
      */
     public static function fromString(string $date) : self
     {
+        $dateNormalized = \trim(\strtolower($date));
         $dateParts = \date_parse($date);
 
         if (!\is_array($dateParts)) {
@@ -68,12 +69,12 @@ final class Month
             throw new InvalidArgumentException("Value \"{$date}\" is not valid month format.");
         }
 
-        if (!\is_int($dateParts['year']) || !\is_int($dateParts['month'])) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid month format.");
+        if (isset($dateParts['relative']) || \in_array($dateNormalized, ['midnight', 'noon', 'now', 'today'], true)) {
+            return self::fromDateTime(new \DateTimeImmutable($date));
         }
 
-        if (isset($dateParts['relative'])) {
-            return self::fromDateTime(new \DateTimeImmutable($date));
+        if (!\is_int($dateParts['year']) || !\is_int($dateParts['month'])) {
+            throw new InvalidArgumentException("Value \"{$date}\" is not valid month format.");
         }
 
         return new self(new Year($dateParts['year']), $dateParts['month']);

--- a/src/Aeon/Calendar/Gregorian/Time.php
+++ b/src/Aeon/Calendar/Gregorian/Time.php
@@ -65,30 +65,31 @@ final class Time
      */
     public static function fromString(string $date) : self
     {
-        $dateParts = \date_parse($date);
+        $dateNormalized = \trim(\strtolower($date));
+        $timeParts = \date_parse($date);
 
-        if (!\is_array($dateParts)) {
+        if (!\is_array($timeParts)) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid time format.");
         }
 
-        if ($dateParts['error_count'] > 0) {
+        if ($timeParts['error_count'] > 0) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid time format.");
         }
 
-        if (!\is_int($dateParts['hour']) || !\is_int($dateParts['minute']) || !\is_int($dateParts['second'])) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid time format.");
-        }
-
-        if (isset($dateParts['relative'])) {
+        if (isset($timeParts['relative']) || \in_array($dateNormalized, ['now', 'today'], true)) {
             return self::fromDateTime(new \DateTimeImmutable($date));
         }
 
+        if (!\is_int($timeParts['hour']) || !\is_int($timeParts['minute']) || !\is_int($timeParts['second'])) {
+            throw new InvalidArgumentException("Value \"{$date}\" is not valid time format.");
+        }
+
         /** @psalm-suppress MixedArgument */
-        $secondsString = \number_format(\round($dateParts['fraction'], self::PRECISION_MICROSECOND, PHP_ROUND_HALF_UP), self::PRECISION_MICROSECOND, '.', '');
+        $secondsString = \number_format(\round($timeParts['fraction'], self::PRECISION_MICROSECOND, PHP_ROUND_HALF_UP), self::PRECISION_MICROSECOND, '.', '');
         $secondsStringParts = \explode('.', $secondsString);
         $microseconds = \abs(\intval($secondsStringParts[1]));
 
-        return new self($dateParts['hour'], $dateParts['minute'], $dateParts['second'], $microseconds);
+        return new self($timeParts['hour'], $timeParts['minute'], $timeParts['second'], $microseconds);
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -19,12 +19,21 @@ use PHPUnit\Framework\TestCase;
 
 final class DateTimeTest extends TestCase
 {
+    public function setUp() : void
+    {
+        \date_default_timezone_set('UTC');
+    }
+
     /**
      * @dataProvider creating_datetime_data_provider
      */
     public function test_creating_datetime(string $dateTimeString, DateTime $dateTime, string $format) : void
     {
-        $this->assertSame($dateTimeString, $dateTime->format($format));
+        try {
+            $this->assertSame($dateTimeString, $dateTime->format($format));
+        } catch (InvalidArgumentException $exception) {
+            $this->fail($exception->getMessage());
+        }
     }
 
     /**
@@ -43,35 +52,74 @@ final class DateTimeTest extends TestCase
         yield ['2020-01-01 00:00:00+01:00', DateTime::create(2020, 01, 01, 00, 00, 00, 0, 'Europe/Warsaw'), 'Y-m-d H:i:sP'];
         yield ['2020-01-01 00:00:00+01:00', DateTime::fromDateTime(new \DateTimeImmutable('2020-01-01 00:00:00+01:00')), 'Y-m-d H:i:sP'];
         yield ['2020-01-01 00:00:00+01:00', new DateTime(new Day(new Month(new Year(2020), 01), 01), new Time(0, 0, 0), TimeZone::europeWarsaw()), 'Y-m-d H:i:sP'];
-        yield ['2020-01-01 00:00:00+00:00', DateTime::fromString('2020-01 00:00:00'), 'Y-m-d H:i:sP'];
-        yield ['2020-01-02 00:00:00+00:00', DateTime::fromString('2020-01 00:00:00 +1 day'), 'Y-m-d H:i:sP'];
-        yield ['2020-01-01 00:00:00+00:00', DateTime::fromString('2020-01 00:00'), 'Y-m-d H:i:sP'];
-        yield ['2020-01-01 00:00:00+00:00.000000', DateTime::fromString('2020-01 00:00'), 'Y-m-d H:i:sP.u'];
-        yield ['2020-01-01 00:00:00+00:00.000500', DateTime::fromString('2020-01 00:00:00.0005'), 'Y-m-d H:i:sP.u'];
-        yield ['1999-10-13 00:00:00', DateTime::fromString('1999-10-13 00:00:00'), 'Y-m-d H:i:s'];
-        yield ['1999-10-13 00:00:00', DateTime::fromString('Oct 13  1999 00:00:00'), 'Y-m-d H:i:s'];
-        yield ['2000-01-19 00:00:00', DateTime::fromString('2000-01-19 00:00:00'), 'Y-m-d H:i:s'];
-        yield ['2000-01-19 00:00:00', DateTime::fromString('Jan 19  2000 00:00:00'), 'Y-m-d H:i:s'];
-        yield ['2001-12-21 00:00:00', DateTime::fromString('2001-12-21 00:00:00'), 'Y-m-d H:i:s'];
-        yield ['2001-12-21 00:00:00', DateTime::fromString('Dec 21  2001 00:00:00'), 'Y-m-d H:i:s'];
-        yield ['2001-12-21 12:16:00', DateTime::fromString('2001-12-21 12:16'), 'Y-m-d H:i:s'];
-        yield ['2001-12-21 12:16:00', DateTime::fromString('Dec 21 2001 12:16'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:19:58', DateTime::fromString('2001-10-22 21:19:58'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:19:58', DateTime::fromString('2001-10-22 21:19:58-02'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:19:58', DateTime::fromString('2001-10-22 21:19:58-0213'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:19:58', DateTime::fromString('2001-10-22 21:19:58+02'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:19:58', DateTime::fromString('2001-10-22 21:19:58+0213'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:20:58', DateTime::fromString('2001-10-22T21:20:58-03:40'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:19:58', DateTime::fromString('2001-10-22T211958-2'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:19:58', DateTime::fromString('20011022T211958+0213'), 'Y-m-d H:i:s'];
-        yield ['2001-10-22 21:20:00', DateTime::fromString('20011022T21:20+0215'), 'Y-m-d H:i:s'];
-        yield ['1996-12-30 00:00:00', DateTime::fromString('1997W011 00:00:00'), 'Y-m-d H:i:s'];
-        yield ['2004-03-01 05:00:00', DateTime::fromString('2004W101T05:00+0'), 'Y-m-d H:i:s'];
+    }
+
+    /**
+     * @dataProvider creating_datetime_data_provider_from_string
+     */
+    public function test_creating_datetime_from_string(string $dateTimeString, string $dateTime, string $format) : void
+    {
+        try {
+            $this->assertSame($dateTimeString, DateTime::fromString($dateTime)->format($format));
+        } catch (InvalidArgumentException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+    /**
+     * @return \Generator<int, array{string, string, string}, mixed, void>
+     */
+    public function creating_datetime_data_provider_from_string() : \Generator
+    {
+        yield ['2020-01-01 00:00:00+00:00', '2020-01 00:00:00', 'Y-m-d H:i:sP'];
+        yield ['2020-01-02 00:00:00+00:00', '2020-01 00:00:00 +1 day', 'Y-m-d H:i:sP'];
+        yield ['2020-01-01 00:00:00+00:00', '2020-01 00:00', 'Y-m-d H:i:sP'];
+        yield ['2020-01-01 00:00:00+00:00.000000', '2020-01 00:00', 'Y-m-d H:i:sP.u'];
+        yield ['2020-01-01 00:00:00+00:00.000500', '2020-01 00:00:00.0005', 'Y-m-d H:i:sP.u'];
+        yield ['1999-10-13 00:00:00', '1999-10-13 00:00:00', 'Y-m-d H:i:s'];
+        yield ['1999-10-13 00:00:00', 'Oct 13  1999 00:00:00', 'Y-m-d H:i:s'];
+        yield ['2000-01-19 00:00:00', '2000-01-19 00:00:00', 'Y-m-d H:i:s'];
+        yield ['2000-01-19 00:00:00', 'Jan 19  2000 00:00:00', 'Y-m-d H:i:s'];
+        yield ['2001-12-21 00:00:00', '2001-12-21 00:00:00', 'Y-m-d H:i:s'];
+        yield ['2001-12-21 00:00:00', 'Dec 21  2001 00:00:00', 'Y-m-d H:i:s'];
+        yield ['2001-12-21 12:16:00', '2001-12-21 12:16', 'Y-m-d H:i:s'];
+        yield ['2001-12-21 12:16:00', 'Dec 21 2001 12:16', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:19:58', '2001-10-22 21:19:58', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:19:58', '2001-10-22 21:19:58-02', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:19:58', '2001-10-22 21:19:58-0213', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:19:58', '2001-10-22 21:19:58+02', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:19:58', '2001-10-22 21:19:58+0213', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:20:58', '2001-10-22T21:20:58-03:40', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:19:58', '2001-10-22T211958-2', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:19:58', '20011022T211958+0213', 'Y-m-d H:i:s'];
+        yield ['2001-10-22 21:20:00', '20011022T21:20+0215', 'Y-m-d H:i:s'];
+        yield ['1996-12-30 00:00:00', '1997W011 00:00:00', 'Y-m-d H:i:s'];
+        yield ['2004-03-01 05:00:00', '2004W101T05:00+0', 'Y-m-d H:i:s'];
         // DTS switch +1 hour
-        yield ['2020-03-29 03:30:00+02:00', DateTime::fromString('2020-03-29 02:30:00 Europe/Warsaw'), 'Y-m-d H:i:sP'];
+        yield ['2020-03-29 03:30:00+02:00', '2020-03-29 02:30:00 Europe/Warsaw', 'Y-m-d H:i:sP'];
         // DTS switch -1 hour
-        yield ['2020-10-25 02:30:00+01:00', DateTime::fromString('2020-10-25 02:30:00 Europe/Warsaw'), 'Y-m-d H:i:sP'];
-        yield ['2020-10-25 01:30:00+02:00', DateTime::fromString('2020-10-25 01:30:00 Europe/Warsaw'), 'Y-m-d H:i:sP'];
+        yield ['2020-10-25 02:30:00+01:00', '2020-10-25 02:30:00 Europe/Warsaw', 'Y-m-d H:i:sP'];
+        yield ['2020-10-25 01:30:00+02:00', '2020-10-25 01:30:00 Europe/Warsaw', 'Y-m-d H:i:sP'];
+
+        yield [(new \DateTimeImmutable('now'))->format('Y-m-d'), 'now', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('now'))->format('Y-m-d'), 'noW', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('today'))->format('Y-m-d'), 'today ', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('noon'))->format('Y-m-d'), ' noON ', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('yesterday noon'))->format('Y-m-d'), 'yesterday noon', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('tomorrow'))->format('Y-m-d'), 'tomorrow', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('tomorrow midnight'))->format('Y-m-d'), 'tomorrow midnight', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('yesterday'))->format('Y-m-d'), 'yesterday', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('midnight'))->format('Y-m-d'), 'midnight', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('24 week'))->format('Y-m-d'), '24 week', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('today +1 hour'))->format('Y-m-d'), 'today +1 hour', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('tomorrow +1 hour'))->format('Y-m-d'), 'tomorrow +1 hour', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('-2 days'))->format('Y-m-d'), '-2 days', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('Monday'))->format('Y-m-d'), 'Monday', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('Monday next week'))->format('Y-m-d'), 'Monday next week', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('next year'))->format('Y-m-d'), 'next year', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('fifth day'))->format('Y-m-d'), 'fifth day', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('last day'))->format('Y-m-d'), 'last day', 'Y-m-d'];
+        yield [(new \DateTimeImmutable('first day of January 2019'))->format('Y-m-d'), 'first day of January 2019', 'Y-m-d'];
     }
 
     /**
@@ -94,6 +142,16 @@ final class DateTimeTest extends TestCase
         yield ['2020-01-32'];
         yield ['something'];
         yield ['00:00:00'];
+    }
+
+    public function test_creating_datetime_from_string_relative_with_system_defualt_timezone_different_from_UTC() : void
+    {
+        \date_default_timezone_set('Europe/Warsaw');
+
+        $dateTime = DateTime::fromString('tomorrow');
+
+        $this->assertSame('UTC', $dateTime->timeZone()->name());
+        $this->assertSame('Europe/Warsaw', \date_default_timezone_get());
     }
 
     public function test_debug_info() : void

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
@@ -49,6 +49,45 @@ final class DayTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider creating_day_data_provider_from_string
+     */
+    public function test_creating_day_from_string(string $dateTimeString, string $dateTime, string $format) : void
+    {
+        try {
+            $this->assertSame($dateTimeString, Day::fromString($dateTime)->format($format));
+        } catch (InvalidArgumentException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+    /**
+     * @return \Generator<int, array{string, string, string}, mixed, void>
+     */
+    public function creating_day_data_provider_from_string() : \Generator
+    {
+        yield [(new \DateTimeImmutable('now'))->format('Y-m-d 00:00:00+00:00'), 'now', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('now'))->format('Y-m-d 00:00:00+00:00'), 'now ', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('today'))->format('Y-m-d 00:00:00+00:00'), 'today', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('today'))->format('Y-m-d 00:00:00+00:00'), ' tOday', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('noon'))->format('Y-m-d 00:00:00+00:00'), 'noon', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('noon'))->format('Y-m-d 00:00:00+00:00'), 'noon  ', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('yesterday noon'))->format('Y-m-d 00:00:00+00:00'), 'yesterday noon', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('tomorrow'))->format('Y-m-d 00:00:00+00:00'), 'tomorrow', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('tomorrow midnight'))->format('Y-m-d 00:00:00+00:00'), 'tomorrow midnight', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('yesterday'))->format('Y-m-d 00:00:00+00:00'), 'yesterday', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('midnight'))->format('Y-m-d 00:00:00+00:00'), 'midnight', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('24 week'))->format('Y-m-d 00:00:00+00:00'), '24 week', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('today +1 hour'))->format('Y-m-d 00:00:00+00:00'), 'today +1 hour', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('tomorrow +1 hour'))->format('Y-m-d 00:00:00+00:00'), 'tomorrow +1 hour', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('-2 days'))->format('Y-m-d 00:00:00+00:00'), '-2 days', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('Monday'))->format('Y-m-d 00:00:00+00:00'), 'Monday', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('Monday next week'))->format('Y-m-d 00:00:00+00:00'), 'Monday next week', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('next year'))->format('Y-m-d 00:00:00+00:00'), 'next year', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('fifth day'))->format('Y-m-d 00:00:00+00:00'), 'fifth day', 'Y-m-d H:i:sP'];
+        yield [(new \DateTimeImmutable('first day of January 2019'))->format('Y-m-d 00:00:00+00:00'), 'first day of January 2019', 'Y-m-d H:i:sP'];
+    }
+
     public function test_to_string() : void
     {
         $this->assertSame(

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
@@ -41,6 +41,45 @@ final class MonthTest extends TestCase
     }
 
     /**
+     * @dataProvider creating_month_data_provider_from_string
+     */
+    public function test_creating_month_from_string(string $dateTimeString, string $dateTime) : void
+    {
+        try {
+            $this->assertSame($dateTimeString, Month::fromString($dateTime)->toString());
+        } catch (InvalidArgumentException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+    /**
+     * @return \Generator<int, array{string, string}, mixed, void>
+     */
+    public function creating_month_data_provider_from_string() : \Generator
+    {
+        yield [(new \DateTimeImmutable('now'))->format('Y-m'), 'now'];
+        yield [(new \DateTimeImmutable('now'))->format('Y-m'), 'NoW'];
+        yield [(new \DateTimeImmutable('today'))->format('Y-m'), 'today'];
+        yield [(new \DateTimeImmutable('today'))->format('Y-m'), 'today '];
+        yield [(new \DateTimeImmutable('noon'))->format('Y-m'), 'noon'];
+        yield [(new \DateTimeImmutable('noon'))->format('Y-m'), ' noon'];
+        yield [(new \DateTimeImmutable('yesterday noon'))->format('Y-m'), 'yesterday noon'];
+        yield [(new \DateTimeImmutable('tomorrow'))->format('Y-m'), 'tomorrow'];
+        yield [(new \DateTimeImmutable('tomorrow midnight'))->format('Y-m'), 'tomorrow midnight'];
+        yield [(new \DateTimeImmutable('yesterday'))->format('Y-m'), 'yesterday'];
+        yield [(new \DateTimeImmutable('midnight'))->format('Y-m'), 'midnight'];
+        yield [(new \DateTimeImmutable('24 week'))->format('Y-m'), '24 week'];
+        yield [(new \DateTimeImmutable('today +1 hour'))->format('Y-m'), 'today +1 hour'];
+        yield [(new \DateTimeImmutable('tomorrow +1 hour'))->format('Y-m'), 'tomorrow +1 hour'];
+        yield [(new \DateTimeImmutable('-2 days'))->format('Y-m'), '-2 days'];
+        yield [(new \DateTimeImmutable('Monday'))->format('Y-m'), 'Monday'];
+        yield [(new \DateTimeImmutable('Monday next week'))->format('Y-m'), 'Monday next week'];
+        yield [(new \DateTimeImmutable('next year'))->format('Y-m'), 'next year'];
+        yield [(new \DateTimeImmutable('fifth day'))->format('Y-m'), 'fifth day'];
+        yield [(new \DateTimeImmutable('first day of January 2019'))->format('Y-m'), 'first day of January 2019'];
+    }
+
+    /**
      * @dataProvider invalid_string_day_format
      */
     public function test_from_invalid_string(string $invalidValue) : void
@@ -58,7 +97,6 @@ final class MonthTest extends TestCase
     {
         yield ['00:01'];
         yield ['2020'];
-        yield ['+1 month'];
         yield ['test'];
     }
 

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
@@ -42,7 +42,6 @@ final class TimeTest extends TestCase
     {
         yield ['01-01-01'];
         yield ['2020-32'];
-        yield ['+1 minute'];
     }
 
     public function test_each_part_of_time() : void
@@ -73,6 +72,35 @@ final class TimeTest extends TestCase
         yield ['01:00:01.00001', new Time(01, 00, 01, 10)];
         yield ['01:12', new Time(01, 12, 00)];
         yield ['01:12 +1 minute + 10 seconds', new Time(01, 13, 10)];
+    }
+
+    /**
+     * @dataProvider creating_time_data_provider_from_string
+     */
+    public function test_creating_time_from_string(string $dateTimeString, string $dateTime, string $format) : void
+    {
+        try {
+            $this->assertEqualsWithDelta((int) $dateTimeString, (int) Time::fromString($dateTime)->format($format), 10);
+        } catch (InvalidArgumentException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+    /**
+     * @return \Generator<int, array{string, string, string}, mixed, void>
+     */
+    public function creating_time_data_provider_from_string() : \Generator
+    {
+        yield [(new \DateTimeImmutable('now'))->format('U'), 'noW', 'U'];
+        yield [(new \DateTimeImmutable('now'))->format('U'), 'now ', 'U'];
+        yield [(new \DateTimeImmutable('today'))->format('U'), 'today', 'U'];
+        yield [(new \DateTimeImmutable('today'))->format('U'), ' tOday', 'U'];
+        yield [(new \DateTimeImmutable('noon'))->format('U'), 'noon', 'U'];
+        yield [(new \DateTimeImmutable('noon'))->format('U'), 'noon  ', 'U'];
+        yield [(new \DateTimeImmutable('midnight'))->format('U'), 'midnight  ', 'U'];
+        yield [(new \DateTimeImmutable('noon +1 minute'))->format('U'), 'noon +1 minute', 'U'];
+        yield [(new \DateTimeImmutable('back of 7pm'))->format('U'), 'back of 7pm', 'U'];
+        yield [(new \DateTimeImmutable('last hour'))->format('U'), 'last hour', 'U'];
     }
 
     public function test_time_millisecond() : void


### PR DESCRIPTION
So my latest big refactoring removed accidentally support for things like `DateTime::fromString('-7 days')`.
I'm not a huge fan of relative formats since many things are then taken implicit but it's really handy when it comes to handling user inputs. 
This PR should bring back relative time formats support. It will be released as `0.13.1` tomorrow