### PR TITLE
Fixed Year::fromString method

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -63,6 +63,7 @@
         "Aeon\\Calendar\\Gregorian\\DateTime::fromString",
         "Aeon\\Calendar\\Gregorian\\Day::fromString",
         "Aeon\\Calendar\\Gregorian\\Month::fromString",
+        "Aeon\\Calendar\\Gregorian\\Year::fromString",
         "Aeon\\Calendar\\Gregorian\\Time::fromString"
       ]
     },
@@ -71,6 +72,7 @@
         "Aeon\\Calendar\\Gregorian\\DateTime::fromString",
         "Aeon\\Calendar\\Gregorian\\Day::fromString",
         "Aeon\\Calendar\\Gregorian\\Month::fromString",
+        "Aeon\\Calendar\\Gregorian\\Year::fromString",
         "Aeon\\Calendar\\Gregorian\\Time::fromString"
       ]
     }

--- a/src/Aeon/Calendar/Gregorian/Year.php
+++ b/src/Aeon/Calendar/Gregorian/Year.php
@@ -37,7 +37,26 @@ final class Year
      */
     public static function fromString(string $date) : self
     {
-        return self::fromDateTime(new \DateTimeImmutable($date));
+        $dateNormalized = \is_numeric($date) ? \sprintf('%d-01-01', $date) : \trim($date);
+        $dateParts = \date_parse($dateNormalized);
+
+        if (!\is_array($dateParts)) {
+            throw new InvalidArgumentException("Value \"{$date}\" is not valid year format.");
+        }
+
+        if ($dateParts['error_count'] > 0) {
+            throw new InvalidArgumentException("Value \"{$date}\" is not valid year format.");
+        }
+
+        if (isset($dateParts['relative']) || \in_array(\strtolower($dateNormalized), ['midnight', 'noon', 'now', 'today'], true)) {
+            return self::fromDateTime(new \DateTimeImmutable($date));
+        }
+
+        if (!isset($dateParts['year']) || !\is_int($dateParts['year'])) {
+            throw new InvalidArgumentException("Value \"{$date}\" is not valid year format.");
+        }
+
+        return new self($dateParts['year']);
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/YearTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/YearTest.php
@@ -28,6 +28,27 @@ final class YearTest extends TestCase
         $this->assertSame(12, Year::fromString('2020-01-01')->december()->number());
     }
 
+    public function test_from_string() : void
+    {
+        $this->assertSame(2018, Year::fromString('2018')->number());
+        $this->assertSame(2020, Year::fromString('2020')->number());
+        $this->assertSame((int) (new \DateTimeImmutable('now'))->format('Y'), Year::fromString('now')->number());
+        $this->assertSame((int) (new \DateTimeImmutable('midnight'))->format('Y'), Year::fromString('midnight')->number());
+        $this->assertSame((int) (new \DateTimeImmutable('yesterday'))->format('Y'), Year::fromString('yesterday')->number());
+        $this->assertSame((int) (new \DateTimeImmutable('yesterday'))->format('Y'), Year::fromString('yesterday ')->number());
+        $this->assertSame((int) (new \DateTimeImmutable('noon'))->format('Y'), Year::fromString('NooN ')->number());
+        $this->assertSame((int) (new \DateTimeImmutable('noon'))->format('Y'), Year::fromString('noon')->number());
+        $this->assertSame((int) (new \DateTimeImmutable('tomorrow'))->format('Y'), Year::fromString('tomorrow')->number());
+    }
+
+    public function test_from_string_that_is_not_valid_number() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectDeprecationMessage('Value "not a number" is not valid year format');
+
+        Year::fromString('not a number');
+    }
+
     public function test_from_date_time_immutable() : void
     {
         $this->assertSame(2020, Year::fromDateTime(new \DateTimeImmutable('2020-05-01'))->number());


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Year::fromString method</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

so `Year::fromString('2020')` is parsed by the PHP as `current year, current month, current day, hour 20, minute 20`. 
Because of that after the new year, `Year::fromString('2020')` started to fail by returning the year 2021.
The library is not using Year::fromString anywhere, so it only affects those who intentionally used this method.   
