### PR TITLE
Added current date to GregorianCalendarStub constructors

### DIFF
--- a/src/Aeon/Calendar/Gregorian/GregorianCalendarStub.php
+++ b/src/Aeon/Calendar/Gregorian/GregorianCalendarStub.php
@@ -14,27 +14,27 @@ final class GregorianCalendarStub implements Calendar
 
     private ?DateTime $currentDate;
 
-    public function __construct(TimeZone $timeZone)
+    public function __construct(TimeZone $timeZone, ?DateTime $currentDate = null)
     {
         $this->timeZone = $timeZone;
-        $this->currentDate = null;
+        $this->currentDate = $currentDate;
     }
 
     /**
      * @psalm-pure
      */
-    public static function UTC() : self
+    public static function UTC(?DateTime $currentDate = null) : self
     {
-        return new self(TimeZone::UTC());
+        return new self(TimeZone::UTC(), $currentDate);
     }
 
     /**
      * @psalm-pure
      * @psalm-suppress ImpureFunctionCall
      */
-    public static function systemDefault() : self
+    public static function systemDefault(?DateTime $currentDate = null) : self
     {
-        return new self(TimeZone::fromString(\date_default_timezone_get()));
+        return new self(TimeZone::fromString(\date_default_timezone_get()), $currentDate);
     }
 
     public function timeZone() : TimeZone


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>possibility to set current date directly through GregorianCalendarStub constructor</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
