### PR TITLE
Turn UTC into valid abbreviation instead of identifier

### DIFF
--- a/src/Aeon/Calendar/Gregorian/TimeZone.php
+++ b/src/Aeon/Calendar/Gregorian/TimeZone.php
@@ -584,7 +584,7 @@ final class TimeZone
         $normalized = \strtolower($identifier);
 
         if ($normalized === 'utc') {
-            return new self('UTC', self::TYPE_IDENTIFIER);
+            throw new InvalidArgumentException('"UTC" is timezone abbreviation, not identifier.');
         }
 
         /** @var string $dateTimeZoneIdentifier */
@@ -698,7 +698,10 @@ final class TimeZone
      */
     public static function allIdentifiers() : array
     {
-        return \array_map(fn (string $identifier) : self => self::id($identifier), \DateTimeZone::listIdentifiers());
+        return \array_map(
+            fn (string $identifier) : self => self::id($identifier),
+            \array_filter(\DateTimeZone::listIdentifiers(), fn (string $identifier) : bool => $identifier !== 'UTC')
+        );
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeZoneTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeZoneTest.php
@@ -31,6 +31,13 @@ final class TimeZoneTest extends TestCase
         TimeZone::id('not_a_timezone');
     }
 
+    public function test_creating_UTC_as_identifier() : void
+    {
+        $this->expectExceptionMessage('"UTC" is timezone abbreviation, not identifier.');
+
+        TimeZone::id('UTC');
+    }
+
     public function test_creating_from_invalid_offset() : void
     {
         $this->expectExceptionMessage('"not_a_timezone" is not a valid time offset.');
@@ -101,14 +108,14 @@ final class TimeZoneTest extends TestCase
 
     public function test_all_timezone_identifiers() : void
     {
-        $this->assertCount(\count(\DateTimeZone::listIdentifiers()), TimeZone::allIdentifiers());
+        // \DateTimeZone returns UTC as timezone ID but it's an timezone abbreviation
+        $this->assertCount(\count(\DateTimeZone::listIdentifiers()) - 1, TimeZone::allIdentifiers());
         $this->assertContainsOnlyInstancesOf(TimeZone::class, TimeZone::allIdentifiers());
     }
 
     public function test_all_timezones() : void
     {
         // \DateTimeZone::listAbbreviations() additionally returns all 25 alphabet letters as list abbreviations keys.
-
         $this->assertCount(\count(\array_keys(\DateTimeZone::listAbbreviations())) - 25, TimeZone::allAbbreviations());
         $this->assertContainsOnlyInstancesOf(TimeZone::class, TimeZone::allAbbreviations());
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>detecting UTC timezone as abbreviation instead of identifier</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

https://3v4l.org/B1Z4U
