### PR TITLE
Huge performance improvement through extra lazy initialization of date & time objects

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -31,7 +31,8 @@
     },
     "MethodCallRemoval": {
       "ignore": [
-        "Aeon\\Calendar\\Gregorian\\TimePeriods::first"
+        "Aeon\\Calendar\\Gregorian\\TimePeriods::first",
+        "Aeon\\Calendar\\TimeUnit::microsecond"
       ]
     },
     "ArrayItemRemoval": {
@@ -70,14 +71,19 @@
         "Aeon\\Calendar\\Gregorian\\Day::fromDateTime",
         "Aeon\\Calendar\\Gregorian\\Month::fromDateTime",
         "Aeon\\Calendar\\Gregorian\\Time::fromDateTime",
-        "Aeon\\Calendar\\Gregorian\\Month::numberOfDays"
+        "Aeon\\Calendar\\Gregorian\\Month::numberOfDays",
+        "Aeon\\Calendar\\Gregorian\\Day::month",
+        "Aeon\\Calendar\\Gregorian\\Day::number"
       ]
     },
     "InstanceOf_": {
       "ignore": [
         "Aeon\\Calculator\\PreciseCalculator::initialize",
         "Aeon\\Calendar\\Gregorian\\LeapSeconds::load",
-        "Aeon\\Calendar\\Gregorian\\DateTime::toDateTimeImmutable"
+        "Aeon\\Calendar\\Gregorian\\DateTime::toDateTimeImmutable",
+        "Aeon\\Calendar\\Gregorian\\Day::fromDateTime",
+        "Aeon\\Calendar\\Gregorian\\Month::fromDateTime",
+        "Aeon\\Calendar\\Gregorian\\Time::fromDateTime"
       ]
     },
     "Throw_": {
@@ -102,6 +108,18 @@
         "Aeon\\Calendar\\Gregorian\\Time::fromString"
       ]
     },
+    "TrueValue": {
+      "ignore": [
+        "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable",
+        "Aeon\\Calendar\\Gregorian\\Day::toDateTimeImmutable",
+        "Aeon\\Calendar\\Gregorian\\Month::toDateTimeImmutable"
+      ]
+    },
+    "LogicalAnd": {
+      "ignore": [
+        "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable"
+      ]
+    },
     "LessThan": {
       "ignore": [
         "Aeon\\Calendar\\Gregorian\\DateTime::add",
@@ -113,10 +131,36 @@
         "Aeon\\Calendar\\Gregorian\\DateTime::add"
       ]
     },
+    "Identical": {
+      "ignore": [
+        "Aeon\\Calendar\\Gregorian\\TimeZone::type",
+        "Aeon\\Calendar\\Gregorian\\TimeZone::name",
+        "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable",
+        "Aeon\\Calendar\\Gregorian\\Month::toDateTimeImmutable"
+      ]
+    },
+    "UnwrapArrayValues": {
+      "ignore": [
+        "Aeon\\Calendar\\Gregorian\\TimePeriods::isEqual"
+      ]
+    },
     "NotIdentical": {
       "ignore": [
+        "Aeon\\Calendar\\Gregorian\\TimeZone::type",
+        "Aeon\\Calendar\\Gregorian\\TimeZone::name",
         "Aeon\\Calendar\\RelativeTimeUnit::inYears",
-        "Aeon\\Calendar\\RelativeTimeUnit::inCalendarMonths"
+        "Aeon\\Calendar\\RelativeTimeUnit::inCalendarMonths",
+        "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable"
+      ]
+    },
+    "FalseValue": {
+      "ignore": [
+        "Aeon\\Calendar\\Gregorian\\TimeZone::type",
+        "Aeon\\Calendar\\Gregorian\\TimeZone::name",
+        "Aeon\\Calendar\\Gregorian\\Month::fromDateTime",
+        "Aeon\\Calendar\\Gregorian\\Month::toDateTimeImmutable",
+        "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable",
+        "Aeon\\Calendar\\Gregorian\\Time::fromDateTime"
       ]
     },
     "Concat": {

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -81,41 +81,18 @@ final class DateTime
      */
     public static function fromString(string $date) : self
     {
-        $dateNormalized = \trim(\strtolower($date));
-        $dateTimeParts = \date_parse($date);
+        $currentPHPTimeZone = \date_default_timezone_get();
+        \date_default_timezone_set('UTC');
 
-        if (!\is_array($dateTimeParts)) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid date time format.");
-        }
-
-        if ($dateTimeParts['error_count'] > 0) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid date time format.");
-        }
-
-        $constructor = function (string $date) : self {
-            $currentPHPTimeZone = \date_default_timezone_get();
-            \date_default_timezone_set('UTC');
+        try {
             $dateTime = self::fromDateTime(new \DateTimeImmutable($date));
-            \date_default_timezone_set($currentPHPTimeZone);
-
-            return $dateTime;
-        };
-
-        if (isset($dateTimeParts['relative'])) {
-            return $constructor($date);
-        }
-
-        foreach (['midnight', 'noon', 'now', 'today'] as $relativeFormat) {
-            if (\substr($dateNormalized, 0, \strlen($relativeFormat)) === $relativeFormat) {
-                return $constructor($date);
-            }
-        }
-
-        if (!\is_int($dateTimeParts['year']) || !\is_int($dateTimeParts['month']) || !\is_int($dateTimeParts['day'])) {
+        } catch (\Exception $e) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid date time format.");
         }
 
-        return $constructor($date);
+        \date_default_timezone_set($currentPHPTimeZone);
+
+        return $dateTime;
     }
 
     /**

--- a/src/Aeon/Calendar/Gregorian/DateTimeIterator.php
+++ b/src/Aeon/Calendar/Gregorian/DateTimeIterator.php
@@ -73,12 +73,10 @@ final class DateTimeIterator implements \Iterator
         return $this->currentDate;
     }
 
-    public function next() : DateTime
+    public function next() : void
     {
         $this->currentDate = $this->currentDate->add($this->timeUnit);
         $this->key++;
-
-        return $this->currentDate;
     }
 
     public function hasNext() : bool

--- a/src/Aeon/Calendar/Gregorian/Day.php
+++ b/src/Aeon/Calendar/Gregorian/Day.php
@@ -71,26 +71,11 @@ final class Day
      */
     public static function fromString(string $date) : self
     {
-        $dateNormalized = \trim(\strtolower($date));
-        $dateParts = \date_parse($date);
-
-        if (!\is_array($dateParts)) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid day format.");
-        }
-
-        if ($dateParts['error_count'] > 0) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid day format.");
-        }
-
-        if (isset($dateParts['relative']) || \in_array($dateNormalized, ['midnight', 'noon', 'now', 'today'], true)) {
+        try {
             return self::fromDateTime(new \DateTimeImmutable($date));
-        }
-
-        if (!\is_int($dateParts['year']) || !\is_int($dateParts['month']) || !\is_int($dateParts['day'])) {
+        } catch (\Exception $e) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid day format.");
         }
-
-        return new self(new Month(new Year($dateParts['year']), $dateParts['month']), $dateParts['day']);
     }
 
     /**

--- a/src/Aeon/Calendar/Gregorian/Day.php
+++ b/src/Aeon/Calendar/Gregorian/Day.php
@@ -14,11 +14,18 @@ use Aeon\Calendar\TimeUnit;
  */
 final class Day
 {
-    private Month $month;
+    /**
+     * @var null|\ReflectionClass<Day>
+     */
+    private static ?\ReflectionClass $reflectionClass = null;
 
-    private int $number;
+    private ?Month $month = null;
+
+    private ?int $number = null;
 
     private ?\DateTimeImmutable $dateTime;
+
+    private bool $clean = true;
 
     public function __construct(Month $month, int $number)
     {
@@ -48,22 +55,24 @@ final class Day
     /**
      * @psalm-pure
      * @psalm-suppress ImpureMethodCall
+     * @psalm-suppress ImpureStaticProperty
+     * @psalm-suppress PropertyTypeCoercion
+     * @psalm-suppress ImpurePropertyAssignment
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress ImpurePropertyAssignment
      */
     public static function fromDateTime(\DateTimeInterface $dateTime) : self
     {
-        /**
-         * @psalm-suppress PossiblyNullArrayAccess
-         * @phpstan-ignore-next-line
-         */
-        [$year, $month, $day] = \sscanf($dateTime->format('Y-m-d'), '%d-%d-%d');
+        if (self::$reflectionClass === null) {
+            self::$reflectionClass = new \ReflectionClass(self::class);
+        }
 
-        return new self(
-            new Month(
-                new Year((int) $year),
-                (int) $month
-            ),
-            (int) $day
-        );
+        $newDay = self::$reflectionClass->newInstanceWithoutConstructor();
+
+        $newDay->dateTime = $dateTime instanceof \DateTime ? \DateTimeImmutable::createFromMutable($dateTime) : $dateTime;
+        $newDay->clean = false;
+
+        return $newDay;
     }
 
     /**
@@ -84,9 +93,9 @@ final class Day
     public function __debugInfo() : array
     {
         return [
-            'year' => $this->month->year()->number(),
-            'month' => $this->month->number(),
-            'day' => $this->number,
+            'year' => $this->month()->year()->number(),
+            'month' => $this->month()->number(),
+            'day' => $this->number(),
         ];
     }
 
@@ -96,8 +105,8 @@ final class Day
     public function __serialize() : array
     {
         return [
-            'month' => $this->month,
-            'number' => $this->number,
+            'month' => $this->month(),
+            'number' => $this->number(),
         ];
     }
 
@@ -223,8 +232,30 @@ final class Day
         );
     }
 
+    /**
+     * @psalm-suppress PossiblyNullArrayAccess
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress PossiblyInvalidPropertyAssignmentValue
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress InvalidNullableReturnType
+     */
     public function month() : Month
     {
+        if ($this->month === null) {
+            /**
+             * @phpstan-ignore-next-line
+             */
+            [$year, $month, $day] = \sscanf($this->dateTime->format('Y-m-d'), '%d-%d-%d');
+
+            $this->month = new Month(
+                new Year((int) $year),
+                (int) $month
+            );
+
+            $this->number = $day;
+        }
+
         return $this->month;
     }
 
@@ -233,8 +264,30 @@ final class Day
         return $this->month()->year();
     }
 
+    /**
+     * @psalm-suppress PossiblyNullArrayAccess
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress PossiblyInvalidPropertyAssignmentValue
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress InvalidNullableReturnType
+     */
     public function number() : int
     {
+        if ($this->number === null) {
+            /**
+             * @phpstan-ignore-next-line
+             */
+            [$year, $month, $day] = \sscanf($this->dateTime->format('Y-m-d'), '%d-%d-%d');
+
+            $this->month = new Month(
+                new Year((int) $year),
+                (int) $month
+            );
+
+            $this->number = $day;
+        }
+
         return $this->number;
     }
 
@@ -279,8 +332,9 @@ final class Day
      */
     public function toDateTimeImmutable() : \DateTimeImmutable
     {
-        if ($this->dateTime === null) {
+        if ($this->dateTime === null || $this->clean === false) {
             $this->dateTime = new \DateTimeImmutable(\sprintf('%d-%d-%d 00:00:00.000000 UTC', $this->month()->year()->number(), $this->month()->number(), $this->number()));
+            $this->clean = true;
         }
 
         return $this->dateTime;

--- a/src/Aeon/Calendar/Gregorian/GregorianCalendar.php
+++ b/src/Aeon/Calendar/Gregorian/GregorianCalendar.php
@@ -55,6 +55,10 @@ final class GregorianCalendar implements Calendar
 
     public function now() : DateTime
     {
+        if ($this->timeZone->name() === 'UTC') {
+            return DateTime::fromDateTime(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+        }
+
         return DateTime::fromDateTime(new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
             ->toTimeZone($this->timeZone);
     }

--- a/src/Aeon/Calendar/Gregorian/GregorianCalendar.php
+++ b/src/Aeon/Calendar/Gregorian/GregorianCalendar.php
@@ -40,17 +40,17 @@ final class GregorianCalendar implements Calendar
 
     public function currentYear() : Year
     {
-        return Year::fromDateTime($this->now()->toDateTimeImmutable());
+        return $this->now()->year();
     }
 
     public function currentMonth() : Month
     {
-        return Month::fromDateTime($this->now()->toDateTimeImmutable());
+        return $this->now()->month();
     }
 
     public function currentDay() : Day
     {
-        return Day::fromDateTime($this->now()->toDateTimeImmutable());
+        return $this->now()->day();
     }
 
     public function now() : DateTime

--- a/src/Aeon/Calendar/Gregorian/GregorianCalendarStub.php
+++ b/src/Aeon/Calendar/Gregorian/GregorianCalendarStub.php
@@ -44,17 +44,17 @@ final class GregorianCalendarStub implements Calendar
 
     public function currentYear() : Year
     {
-        return Year::fromDateTime($this->now()->toDateTimeImmutable());
+        return $this->now()->year();
     }
 
     public function currentMonth() : Month
     {
-        return Month::fromDateTime($this->now()->toDateTimeImmutable());
+        return $this->now()->month();
     }
 
     public function currentDay() : Day
     {
-        return Day::fromDateTime($this->now()->toDateTimeImmutable());
+        return $this->now()->day();
     }
 
     public function now() : DateTime

--- a/src/Aeon/Calendar/Gregorian/Month.php
+++ b/src/Aeon/Calendar/Gregorian/Month.php
@@ -63,26 +63,11 @@ final class Month
      */
     public static function fromString(string $date) : self
     {
-        $dateNormalized = \trim(\strtolower($date));
-        $dateParts = \date_parse($date);
-
-        if (!\is_array($dateParts)) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid month format.");
-        }
-
-        if ($dateParts['error_count'] > 0) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid month format.");
-        }
-
-        if (isset($dateParts['relative']) || \in_array($dateNormalized, ['midnight', 'noon', 'now', 'today'], true)) {
+        try {
             return self::fromDateTime(new \DateTimeImmutable($date));
-        }
-
-        if (!\is_int($dateParts['year']) || !\is_int($dateParts['month'])) {
+        } catch (\Exception $e) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid month format.");
         }
-
-        return new self(new Year($dateParts['year']), $dateParts['month']);
     }
 
     /**

--- a/src/Aeon/Calendar/Gregorian/Time.php
+++ b/src/Aeon/Calendar/Gregorian/Time.php
@@ -14,13 +14,22 @@ final class Time
 {
     private const PRECISION_MICROSECOND = 6;
 
-    private int $hour;
+    /**
+     * @var null|\ReflectionClass<Time>
+     */
+    private static ?\ReflectionClass $reflectionClass = null;
 
-    private int $minute;
+    private ?int $hour = null;
 
-    private int $second;
+    private ?int $minute = null;
 
-    private int $microsecond;
+    private ?int $second = null;
+
+    private ?int $microsecond = null;
+
+    private ?\DateTimeImmutable $dateTime = null;
+
+    private bool $clean = true;
 
     public function __construct(int $hour, int $minute, int $second, int $microsecond = 0)
     {
@@ -49,16 +58,24 @@ final class Time
     /**
      * @psalm-pure
      * @psalm-suppress ImpureMethodCall
+     * @psalm-suppress ImpureStaticProperty
+     * @psalm-suppress PropertyTypeCoercion
+     * @psalm-suppress ImpurePropertyAssignment
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress ImpurePropertyAssignment
      */
     public static function fromDateTime(\DateTimeInterface $dateTime) : self
     {
-        /**
-         * @psalm-suppress PossiblyNullArrayAccess
-         * @phpstan-ignore-next-line
-         */
-        [$hour, $minute, $second, $microsecond] = \sscanf($dateTime->format('H-i-s.u'), '%d-%d-%d.%d');
+        if (self::$reflectionClass === null) {
+            self::$reflectionClass = new \ReflectionClass(self::class);
+        }
 
-        return new self((int) $hour, (int) $minute, (int) $second, (int) $microsecond);
+        $newTime = self::$reflectionClass->newInstanceWithoutConstructor();
+
+        $newTime->dateTime = $dateTime instanceof \DateTime ? \DateTimeImmutable::createFromMutable($dateTime) : $dateTime;
+        $newTime->clean = false;
+
+        return $newTime;
     }
 
     /**
@@ -79,10 +96,10 @@ final class Time
     public function __debugInfo() : array
     {
         return [
-            'hour' => $this->hour,
-            'minute' => $this->minute,
-            'second' => $this->second,
-            'microsecond' => $this->microsecond,
+            'hour' => $this->hour(),
+            'minute' => $this->minute(),
+            'second' => $this->second(),
+            'microsecond' => $this->microsecond(),
         ];
     }
 
@@ -92,10 +109,10 @@ final class Time
     public function __serialize() : array
     {
         return [
-            'hour' => $this->hour,
-            'minute' => $this->minute,
-            'second' => $this->second,
-            'microsecond' => $this->microsecond,
+            'hour' => $this->hour(),
+            'minute' => $this->minute(),
+            'second' => $this->second(),
+            'microsecond' => $this->microsecond(),
         ];
     }
 
@@ -113,29 +130,101 @@ final class Time
 
     public function toString() : string
     {
-        return \str_pad((string) $this->hour, 2, '0', STR_PAD_LEFT) . ':'
-            . \str_pad((string) $this->minute, 2, '0', STR_PAD_LEFT) . ':'
-            . \str_pad((string) $this->second, 2, '0', STR_PAD_LEFT) . '.'
-            . \str_pad((string) $this->microsecond, self::PRECISION_MICROSECOND, '0', STR_PAD_LEFT);
+        return \str_pad((string) $this->hour(), 2, '0', STR_PAD_LEFT) . ':'
+            . \str_pad((string) $this->minute(), 2, '0', STR_PAD_LEFT) . ':'
+            . \str_pad((string) $this->second(), 2, '0', STR_PAD_LEFT) . '.'
+            . \str_pad((string) $this->microsecond(), self::PRECISION_MICROSECOND, '0', STR_PAD_LEFT);
     }
 
+    /**
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress PossiblyInvalidPropertyAssignmentValue
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress PossiblyNullArrayAccess
+     * @psalm-suppress InvalidNullableReturnType
+     */
     public function hour() : int
     {
+        if ($this->hour === null) {
+            /** @phpstan-ignore-next-line */
+            [$hour, $minute, $second, $microsecond] = \sscanf($this->dateTime->format('H-i-s.u'), '%d-%d-%d.%d');
+
+            $this->hour = $hour;
+            $this->minute = $minute;
+            $this->second = $second;
+            $this->microsecond = $microsecond;
+        }
+
         return $this->hour;
     }
 
+    /**
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress PossiblyInvalidPropertyAssignmentValue
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress PossiblyNullArrayAccess
+     * @psalm-suppress InvalidNullableReturnType
+     */
     public function minute() : int
     {
+        if ($this->minute === null) {
+            /** @phpstan-ignore-next-line */
+            [$hour, $minute, $second, $microsecond] = \sscanf($this->dateTime->format('H-i-s.u'), '%d-%d-%d.%d');
+
+            $this->hour = $hour;
+            $this->minute = $minute;
+            $this->second = $second;
+            $this->microsecond = $microsecond;
+        }
+
         return $this->minute;
     }
 
+    /**
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress PossiblyInvalidPropertyAssignmentValue
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress PossiblyNullArrayAccess
+     * @psalm-suppress InvalidNullableReturnType
+     */
     public function second() : int
     {
+        if ($this->second === null) {
+            /** @phpstan-ignore-next-line */
+            [$hour, $minute, $second, $microsecond] = \sscanf($this->dateTime->format('H-i-s.u'), '%d-%d-%d.%d');
+
+            $this->hour = $hour;
+            $this->minute = $minute;
+            $this->second = $second;
+            $this->microsecond = $microsecond;
+        }
+
         return $this->second;
     }
 
+    /**
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress PossiblyInvalidPropertyAssignmentValue
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress PossiblyNullArrayAccess
+     * @psalm-suppress InvalidNullableReturnType
+     */
     public function microsecond() : int
     {
+        if ($this->microsecond === null) {
+            /** @phpstan-ignore-next-line */
+            [$hour, $minute, $second, $microsecond] = \sscanf($this->dateTime->format('H-i-s.u'), '%d-%d-%d.%d');
+
+            $this->hour = $hour;
+            $this->minute = $minute;
+            $this->second = $second;
+            $this->microsecond = $microsecond;
+        }
+
         return $this->microsecond;
     }
 
@@ -204,14 +293,34 @@ final class Time
         return self::fromDateTime($this->toDateTimeImmutable()->sub($timeUnit->toDateInterval()));
     }
 
+    /**
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress InvalidNullableReturnType
+     */
     private function toDateTimeImmutable() : \DateTimeImmutable
     {
-        return (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
-            ->setTime(
-                $this->hour(),
-                $this->minute(),
-                $this->second(),
-                $this->microsecond()
-            );
+        if ($this->dateTime === null) {
+            $this->dateTime = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+                ->setTime(
+                    $this->hour(),
+                    $this->minute(),
+                    $this->second(),
+                    $this->microsecond()
+                );
+        }
+
+        if ($this->dateTime !== null && $this->clean === false) {
+            $this->dateTime = $this->dateTime
+                ->setTime(
+                    $this->hour(),
+                    $this->minute(),
+                    $this->second(),
+                    $this->microsecond()
+                );
+            $this->clean = true;
+        }
+
+        return $this->dateTime;
     }
 }

--- a/src/Aeon/Calendar/Gregorian/Time.php
+++ b/src/Aeon/Calendar/Gregorian/Time.php
@@ -64,36 +64,13 @@ final class Time
     /**
      * @psalm-pure
      */
-    public static function fromString(string $date) : self
+    public static function fromString(string $time) : self
     {
-        $dateNormalized = \trim(\strtolower($date));
-        $timeParts = \date_parse($date);
-
-        if (!\is_array($timeParts)) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid time format.");
+        try {
+            return self::fromDateTime(new \DateTimeImmutable($time));
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException("Value \"{$time}\" is not valid time format.");
         }
-
-        if ($timeParts['error_count'] > 0) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid time format.");
-        }
-
-        if (isset($timeParts['relative']) || \in_array($dateNormalized, ['now', 'today'], true)) {
-            return self::fromDateTime(new \DateTimeImmutable($date));
-        }
-
-        if (!\is_int($timeParts['hour']) || !\is_int($timeParts['minute']) || !\is_int($timeParts['second'])) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid time format.");
-        }
-
-        /**
-         * @psalm-suppress MixedArgument
-         * @phpstan-ignore-next-line
-         */
-        $secondsString = \number_format(\round($timeParts['fraction'], self::PRECISION_MICROSECOND, PHP_ROUND_HALF_UP), self::PRECISION_MICROSECOND, '.', '');
-        $secondsStringParts = \explode('.', $secondsString);
-        $microseconds = \abs(\intval($secondsStringParts[1]));
-
-        return new self($timeParts['hour'], $timeParts['minute'], $timeParts['second'], $microseconds);
     }
 
     /**

--- a/src/Aeon/Calendar/Gregorian/TimePeriods.php
+++ b/src/Aeon/Calendar/Gregorian/TimePeriods.php
@@ -174,4 +174,22 @@ final class TimePeriods implements \Countable, \IteratorAggregate
     {
         return self::fromArray(...\array_merge($this->all(), $timePeriods->all()));
     }
+
+    public function isEqual(self $periods) : bool
+    {
+        if ($periods->count() !== $this->count()) {
+            return false;
+        }
+
+        $selfArray = \array_values($this->sort()->all());
+        $periodsArray = \array_values($periods->sort()->all());
+
+        foreach ($selfArray as $i => $timePeriod) {
+            if (!$periodsArray[$i]->isEqual($timePeriod)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Aeon/Calendar/Gregorian/TimeZone.php
+++ b/src/Aeon/Calendar/Gregorian/TimeZone.php
@@ -688,12 +688,22 @@ final class TimeZone
         $name = $dateTimeZone->getName();
         $type = self::TYPE_IDENTIFIER;
 
+        if ($name === 'UTC') {
+            $type = self::TYPE_ABBREVIATION;
+
+            return new self($name, $type);
+        }
+
         if (TimeOffset::isValid($name)) {
             $type = self::TYPE_OFFSET;
+
+            return new self($name, $type);
         }
 
         if (\timezone_name_from_abbr($name) !== false) {
             $type = self::TYPE_ABBREVIATION;
+
+            return new self($name, $type);
         }
 
         return new self($name, $type);

--- a/src/Aeon/Calendar/Gregorian/TimeZone.php
+++ b/src/Aeon/Calendar/Gregorian/TimeZone.php
@@ -563,9 +563,16 @@ final class TimeZone
 
     private const TYPE_IDENTIFIER = 3;
 
-    private string $name;
+    /**
+     * @var null|\ReflectionClass<TimeZone>
+     */
+    private static ?\ReflectionClass $reflectionClass = null;
 
-    private int $type;
+    private ?string $name = null;
+
+    private ?int $type = null;
+
+    private ?\DateTimeZone $dateTimeZone = null;
 
     private function __construct(string $name, int $type)
     {
@@ -680,33 +687,26 @@ final class TimeZone
 
     /**
      * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
+     * @psalm-suppress ImpureStaticProperty
+     * @psalm-suppress PropertyTypeCoercion
+     * @psalm-suppress InvalidNullableReturnType
+     * @psalm-suppress ImpurePropertyAssignment
+     * @psalm-suppress InaccessibleProperty
      *
      * @throws InvalidArgumentException
      */
     public static function fromDateTimeZone(\DateTimeZone $dateTimeZone) : self
     {
-        $name = $dateTimeZone->getName();
-        $type = self::TYPE_IDENTIFIER;
-
-        if ($name === 'UTC') {
-            $type = self::TYPE_ABBREVIATION;
-
-            return new self($name, $type);
+        if (self::$reflectionClass === null) {
+            self::$reflectionClass = new \ReflectionClass(self::class);
         }
 
-        if (TimeOffset::isValid($name)) {
-            $type = self::TYPE_OFFSET;
+        $newTimeZone = self::$reflectionClass->newInstanceWithoutConstructor();
 
-            return new self($name, $type);
-        }
+        $newTimeZone->dateTimeZone = $dateTimeZone;
 
-        if (\timezone_name_from_abbr($name) !== false) {
-            $type = self::TYPE_ABBREVIATION;
-
-            return new self($name, $type);
-        }
-
-        return new self($name, $type);
+        return $newTimeZone;
     }
 
     /**
@@ -765,33 +765,69 @@ final class TimeZone
     public function __serialize() : array
     {
         return [
-            'name' => $this->name,
-            'type' => $this->type,
+            'name' => $this->name(),
+            'type' => $this->type(),
         ];
     }
 
     public function isOffset() : bool
     {
-        return $this->type === self::TYPE_OFFSET;
+        return $this->type() === self::TYPE_OFFSET;
     }
 
     public function isAbbreviation() : bool
     {
-        return $this->type === self::TYPE_ABBREVIATION;
+        return $this->type() === self::TYPE_ABBREVIATION;
     }
 
     public function isIdentifier() : bool
     {
-        return $this->type === self::TYPE_IDENTIFIER;
+        return $this->type() === self::TYPE_IDENTIFIER;
     }
 
+    /**
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress InvalidNullableReturnType
+     */
     public function toDateTimeZone() : \DateTimeZone
     {
-        return new \DateTimeZone($this->name);
+        if ($this->dateTimeZone === null) {
+            $this->dateTimeZone = new \DateTimeZone($this->name());
+        }
+
+        return $this->dateTimeZone;
     }
 
+    /**
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress InvalidNullableReturnType
+     */
     public function name() : string
     {
+        if ($this->name === null) {
+            /** @phpstan-ignore-next-line */
+            $name = $this->dateTimeZone->getName();
+            $type = self::TYPE_IDENTIFIER;
+
+            if ($name === 'UTC') {
+                $type = self::TYPE_ABBREVIATION;
+            }
+
+            if (TimeOffset::isValid($name)) {
+                $type = self::TYPE_OFFSET;
+            }
+
+            if (\timezone_name_from_abbr($name) !== false) {
+                $type = self::TYPE_ABBREVIATION;
+            }
+
+            $this->type = $type;
+            $this->name = $name;
+        }
+
         return $this->name;
     }
 
@@ -802,5 +838,37 @@ final class TimeZone
     public function timeOffset(DateTime $dateTime) : TimeOffset
     {
         return TimeOffset::fromTimeUnit(TimeUnit::seconds($this->toDateTimeZone()->getOffset($dateTime->toDateTimeImmutable())));
+    }
+
+    /**
+     * @psalm-suppress NullableReturnStatement
+     * @psalm-suppress InvalidNullableReturnType
+     * @psalm-suppress InaccessibleProperty
+     * @psalm-suppress PossiblyNullReference
+     */
+    private function type() : int
+    {
+        if ($this->type === null) {
+            /** @phpstan-ignore-next-line */
+            $name = $this->dateTimeZone->getName();
+            $type = self::TYPE_IDENTIFIER;
+
+            if ($name === 'UTC') {
+                $type = self::TYPE_ABBREVIATION;
+            }
+
+            if (TimeOffset::isValid($name)) {
+                $type = self::TYPE_OFFSET;
+            }
+
+            if (\timezone_name_from_abbr($name) !== false) {
+                $type = self::TYPE_ABBREVIATION;
+            }
+
+            $this->type = $type;
+            $this->name = $name;
+        }
+
+        return $this->type;
     }
 }

--- a/src/Aeon/Calendar/Gregorian/Year.php
+++ b/src/Aeon/Calendar/Gregorian/Year.php
@@ -37,26 +37,15 @@ final class Year
      */
     public static function fromString(string $date) : self
     {
-        $dateNormalized = \is_numeric($date) ? \sprintf('%d-01-01', $date) : \trim($date);
-        $dateParts = \date_parse($dateNormalized);
+        try {
+            if (\is_numeric($date)) {
+                return new self((int) $date);
+            }
 
-        if (!\is_array($dateParts)) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid year format.");
-        }
-
-        if ($dateParts['error_count'] > 0) {
-            throw new InvalidArgumentException("Value \"{$date}\" is not valid year format.");
-        }
-
-        if (isset($dateParts['relative']) || \in_array(\strtolower($dateNormalized), ['midnight', 'noon', 'now', 'today'], true)) {
             return self::fromDateTime(new \DateTimeImmutable($date));
-        }
-
-        if (!\is_int($dateParts['year'])) {
+        } catch (\Exception $e) {
             throw new InvalidArgumentException("Value \"{$date}\" is not valid year format.");
         }
-
-        return new self($dateParts['year']);
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -158,7 +158,6 @@ final class DateTimeTest extends TestCase
         yield ['2020-31-01'];
         yield ['2020-01-32'];
         yield ['something'];
-        yield ['00:00:00'];
     }
 
     public function test_creating_datetime_from_string_relative_with_system_default_timezone_different_from_UTC() : void

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
@@ -120,7 +120,7 @@ final class DayTest extends TestCase
      */
     public function test_from_string(string $invalidValue, Day $month) : void
     {
-        $this->assertEquals($month, Day::fromString($invalidValue));
+        $this->assertObjectEquals($month, Day::fromString($invalidValue), 'isEqual');
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DayTest.php
@@ -112,9 +112,7 @@ final class DayTest extends TestCase
      */
     public function invalid_string_day_format() : \Generator
     {
-        yield ['00:01'];
         yield ['2020-32'];
-        yield ['2020'];
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DaysTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DaysTest.php
@@ -48,11 +48,12 @@ final class DaysTest extends TestCase
             Day::fromString('2002-01-03')
         );
 
-        $this->assertEquals(
+        $this->assertObjectEquals(
             Day::fromString('2002-01-01'),
             $days->filter(function (Day $day) {
                 return $day->number() === 1;
-            })->all()[0]
+            })->all()[0],
+            'isEqual'
         );
     }
 

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
@@ -103,7 +103,7 @@ final class MonthTest extends TestCase
      */
     public function test_from_string(string $invalidValue, Month $month) : void
     {
-        $this->assertEquals($month, Month::fromString($invalidValue));
+        $this->assertObjectEquals($month, Month::fromString($invalidValue), 'isEqual');
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
@@ -95,8 +95,6 @@ final class MonthTest extends TestCase
      */
     public function invalid_string_day_format() : \Generator
     {
-        yield ['00:01'];
-        yield ['2020'];
         yield ['test'];
     }
 

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthsIteratorTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthsIteratorTest.php
@@ -26,7 +26,7 @@ final class MonthsIteratorTest extends TestCase
 
         $array = \iterator_to_array(MonthsIterator::fromDateTimeIterator(new DateTimeIntervalIterator($begin, $end, $timeUnit, Interval::closed()))->reverse());
 
-        $this->assertEquals($array[0], Month::fromString('2021-01-01 00:00:00 UTC'));
-        $this->assertEquals($array[12], Month::fromString('2020-01-01 00:00:00 UTC'));
+        $this->assertObjectEquals($array[0], Month::fromString('2021-01-01 00:00:00 UTC'), 'isEqual');
+        $this->assertObjectEquals($array[12], Month::fromString('2020-01-01 00:00:00 UTC'), 'isEqual');
     }
 }

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodsTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimePeriodsTest.php
@@ -65,7 +65,7 @@ final class TimePeriodsTest extends TestCase
 
     public function test_gap_periods() : void
     {
-        $this->assertEquals(
+        $this->assertObjectEquals(
             (TimePeriods::fromArray(
                 new TimePeriod(DateTime::fromString('2020-01-02 00:00:00.000000'), DateTime::fromString('2020-01-03 00:00:00.000000')),
                 new TimePeriod(DateTime::fromString('2020-01-07 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000000')),
@@ -75,7 +75,46 @@ final class TimePeriodsTest extends TestCase
                 new TimePeriod(DateTime::fromString('2020-01-01 00:00:00.000000'), DateTime::fromString('2020-01-02 00:00:00.000000')),
                 new TimePeriod(DateTime::fromString('2020-01-05 00:00:00.000000'), DateTime::fromString('2020-01-07 00:00:00.000000')),
                 new TimePeriod(DateTime::fromString('2020-01-03 00:00:00.000000'), DateTime::fromString('2020-01-06 00:00:00.000000')),
-            ))->gaps()
+            ))->gaps(),
+            'isEqual'
+        );
+    }
+
+    public function test_compare_different_periods() : void
+    {
+        $this->assertFalse(
+            (TimePeriods::fromArray(
+                new TimePeriod(DateTime::fromString('2020-01-02 00:00:00.000000'), DateTime::fromString('2020-01-03 00:00:00.000000')),
+                new TimePeriod(DateTime::fromString('2020-01-07 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000000')),
+            ))->isEqual((TimePeriods::fromArray(
+                new TimePeriod(DateTime::fromString('2020-01-10 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000000')),
+                new TimePeriod(DateTime::fromString('2020-01-01 00:00:00.000000'), DateTime::fromString('2020-01-02 00:00:00.000000')),
+                new TimePeriod(DateTime::fromString('2020-01-05 00:00:00.000000'), DateTime::fromString('2020-01-07 00:00:00.000000')),
+                new TimePeriod(DateTime::fromString('2020-01-03 00:00:00.000000'), DateTime::fromString('2020-01-06 00:00:00.000000')),
+            )))
+        );
+
+        $this->assertFalse(
+            (TimePeriods::fromArray(
+                new TimePeriod(DateTime::fromString('2020-01-02 00:00:00.000000'), DateTime::fromString('2020-01-03 00:00:00.000000')),
+                new TimePeriod(DateTime::fromString('2020-01-07 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000000')),
+            ))->isEqual((TimePeriods::fromArray(
+                new TimePeriod(DateTime::fromString('2020-01-02 00:00:00.000000'), DateTime::fromString('2020-01-03 00:00:00.000000')),
+                new TimePeriod(DateTime::fromString('2020-01-07 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000001')),
+            )))
+        );
+    }
+
+    public function test_compare_identical_periods() : void
+    {
+        $this->assertTrue(
+            (TimePeriods::fromArray(
+                new TimePeriod(DateTime::fromString('2020-01-02 00:00:00.000000'), DateTime::fromString('2020-01-03 00:00:00.000000')),
+                new TimePeriod(DateTime::fromString('2020-01-07 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000000')),
+            ))->isEqual((TimePeriods::fromArray(
+                new TimePeriod(DateTime::fromString('2020-01-02 00:00:00.000000'), DateTime::fromString('2020-01-03 00:00:00.000000')),
+                new TimePeriod(DateTime::fromString('2020-01-07 00:00:00.000000'), DateTime::fromString('2020-01-08 00:00:00.000000')),
+            )))
         );
     }
 

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
@@ -40,7 +40,6 @@ final class TimeTest extends TestCase
      */
     public function invalid_string_day_format() : \Generator
     {
-        yield ['01-01-01'];
         yield ['2020-32'];
     }
 

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
@@ -58,7 +58,7 @@ final class TimeTest extends TestCase
      */
     public function test_from_string(string $invalidValue, Time $time) : void
     {
-        $this->assertEquals($time, Time::fromString($invalidValue));
+        $this->assertObjectEquals($time, Time::fromString($invalidValue), 'isEqual');
     }
 
     /**

--- a/tests/Aeon/Calendar/Tests/Unit/TimeUnitTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/TimeUnitTest.php
@@ -11,6 +11,13 @@ use PHPUnit\Framework\TestCase;
 
 final class TimeUnitTest extends TestCase
 {
+    public function test_invert() : void
+    {
+        $timeUnit = TimeUnit::day()->invert();
+
+        $this->assertSame(-86400, $timeUnit->inSeconds());
+    }
+
     public function test_creating_with_negative_seconds() : void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -415,7 +422,7 @@ final class TimeUnitTest extends TestCase
      */
     public function test_creating_from_date_interval(\DateInterval $dateInterval, TimeUnit $timeUnit) : void
     {
-        $this->assertEquals(TimeUnit::fromDateInterval($dateInterval), $timeUnit);
+        $this->assertObjectEquals(TimeUnit::fromDateInterval($dateInterval), $timeUnit, 'isEqual');
     }
 
     /**
@@ -443,7 +450,7 @@ final class TimeUnitTest extends TestCase
      */
     public function test_creating_from_date_string(string $dateString, TimeUnit $timeUnit) : void
     {
-        $this->assertEquals(TimeUnit::fromDateString($dateString), $timeUnit);
+        $this->assertObjectEquals(TimeUnit::fromDateString($dateString), $timeUnit, 'isEqual');
     }
 
     /**


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>memoization of DateTimeImmutable in all date & time elements</li>
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Before due to a large amount of logic in constructors of the following objects, simple initialization of DateTime cost us 4ms when instead pure \DateTimeImutable costs us almost nothing. 

- DateTime
- Day
- Month
- Year
- TimeZone
- TimeUnit 
- Time 

All of those objects internally are built on top of \DateTimeImmutable od \DateTimeTimezone, and now thanks to extra lazy initialization, static constructors that are using those objects (createFromDateTime or createFromString) are now using reflection to initialize objects without constructors saving an only instance of \DateTime objects internally. 
Later whenever something is needed, that \DateTime object is used internally to get and cache required values which makes initialization of aeon objects extremally fast but also a bit "dirty" 

So long story short, this PR comes with a huge performance boost but since it was possible due to "hacks" aeon objects are not as pure as they were previously (you can see that by a number of psalm suppressions I had to add). 

Below 2 profiles of the following script: 

```
<?php

require_once __DIR__ . '/../vendor/autoload.php';

for ($i = 0; $i < 1000; $i++) {
    $date = \Aeon\Calendar\Gregorian\DateTime::fromString("2022-01-01 00:00:00");
}
```

[Before this PR](https://blackfire.io/profiles/23f4e47d-de9b-4e0b-9137-92325da88e46/graph)
[After this PR](https://blackfire.io/profiles/38da74e9-bcee-4933-95af-534a9108221c/graph)

As you can see the boos is significant when we use Calendar instance:

```
<?php

require_once __DIR__ . '/../vendor/autoload.php';

$calendar = new \Aeon\Calendar\Gregorian\GregorianCalendar(\Aeon\Calendar\Gregorian\TimeZone::UTC());

for ($i = 0; $i < 1000; $i++) {
    $date = $calendar->now();
}
```

[Before this PR](https://blackfire.io/profiles/2b56d57e-470c-4f96-a348-5e91ed71576a/graph)
[After this PR](https://blackfire.io/profiles/62013fd5-41c4-41e2-a2d9-c523e044652e/graph)

And it will be even more significant for all libraries depending on this library, but the objects are no longer pure and truly immutable (even that for the external user they are) 