### PR TITLE
Fixed isAmbiguous bug at PHP 8.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d736f60b8ce6435399bbf0d77a26db6",
+    "content-hash": "7f2d2c0c8b705a26c833abd7543614ad",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4.2 || ^8.0 || ^8.1"
+        "php": "^7.4.2 || ~8.0 || ~8.1"
     },
     "platform-dev": {
         "ext-bcmath": "*"

--- a/infection.json
+++ b/infection.json
@@ -42,12 +42,14 @@
     },
     "IncrementInteger": {
       "ignore": [
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous",
         "Aeon\\Calendar\\Stopwatch::elapsedTime",
         "Aeon\\Calendar\\Gregorian\\Day\\WeekDay::*"
       ]
     },
     "DecrementInteger": {
       "ignore": [
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous",
         "Aeon\\Calendar\\Stopwatch::elapsedTime",
         "Aeon\\Calendar\\RelativeTimeUnit::month",
         "Aeon\\Calendar\\RelativeTimeUnit::year",
@@ -80,6 +82,7 @@
       "ignore": [
         "Aeon\\Calculator\\PreciseCalculator::initialize",
         "Aeon\\Calendar\\Gregorian\\LeapSeconds::load",
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous",
         "Aeon\\Calendar\\Gregorian\\DateTime::toDateTimeImmutable",
         "Aeon\\Calendar\\Gregorian\\Day::fromDateTime",
         "Aeon\\Calendar\\Gregorian\\Month::fromDateTime",
@@ -110,6 +113,7 @@
     },
     "TrueValue": {
       "ignore": [
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous",
         "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable",
         "Aeon\\Calendar\\Gregorian\\Day::toDateTimeImmutable",
         "Aeon\\Calendar\\Gregorian\\Month::toDateTimeImmutable"
@@ -117,11 +121,13 @@
     },
     "LogicalAnd": {
       "ignore": [
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous",
         "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable"
       ]
     },
     "LessThan": {
       "ignore": [
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous",
         "Aeon\\Calendar\\Gregorian\\DateTime::add",
         "Aeon\\Calendar\\Gregorian\\Month::minusMonths"
       ]
@@ -150,11 +156,23 @@
         "Aeon\\Calendar\\Gregorian\\TimeZone::name",
         "Aeon\\Calendar\\RelativeTimeUnit::inYears",
         "Aeon\\Calendar\\RelativeTimeUnit::inCalendarMonths",
-        "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable"
+        "Aeon\\Calendar\\Gregorian\\Time::toDateTimeImmutable",
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous"
+      ]
+    },
+    "Continue_": {
+      "ignore": [
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous"
+      ]
+    },
+    "Foreach_": {
+      "ignore": [
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous"
       ]
     },
     "FalseValue": {
       "ignore": [
+        "Aeon\\Calendar\\Gregorian\\DateTime::isAmbiguous",
         "Aeon\\Calendar\\Gregorian\\TimeZone::type",
         "Aeon\\Calendar\\Gregorian\\TimeZone::name",
         "Aeon\\Calendar\\Gregorian\\Month::fromDateTime",

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -666,7 +666,6 @@ final class DateTime
             return false;
         }
 
-
         if (PHP_VERSION_ID < 80100) {
             /**
              * @var array<int, array{ts: int, time: string, offset: int, isdst: bool, abbr: string}> $transitions
@@ -686,7 +685,6 @@ final class DateTime
 
             return true;
         }
-
 
         /**
          * @var array<int, array{ts: int, time: string, offset: int, isdst: bool, abbr: string}> $transitions

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -914,37 +914,51 @@ final class DateTimeTest extends TestCase
     }
 
     /**
-     * @dataProvider checking_ambiguous_time_data_provider
+     * @dataProvider ambiguous_time_data_provider
      */
-    public function test_checking_is_ambiguous(DateTime $dateTime, bool $ambiguous) : void
+    public function test_checking_is_ambiguous(DateTime $dateTime) : void
     {
-        $this->assertSame($ambiguous, $dateTime->isAmbiguous());
+        $this->assertTrue($dateTime->isAmbiguous());
     }
 
     /**
-     * @return \Generator<int, array{DateTime, bool}, mixed, void>
+     * @return \Generator<int, array{DateTime}, mixed, void>
      */
-    public function checking_ambiguous_time_data_provider() : \Generator
+    public function ambiguous_time_data_provider() : \Generator
     {
-        yield [new DateTime(Day::fromString('2020-01-01'), Time::fromString('00:00:00'), TimeZone::UTC()), false];
-        yield [DateTime::fromString('2020-10-25 01:59:59 UTC'), false];
-        yield [DateTime::fromString('2020-10-25 00:00:00 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-10-25 01:00:00 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-10-25 01:59:59 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-10-25 02:00:00 Europe/Warsaw'), true];
-        yield [DateTime::fromString('2020-10-25 02:30:30 Europe/Warsaw'), true];
-        yield [DateTime::fromString('2020-10-25 02:59:59 Europe/Warsaw'), true];
-        yield [DateTime::fromString('2020-10-25 03:00:00 Europe/Warsaw'), true];
-        yield [DateTime::fromString('2020-10-25 03:01:00 Europe/Warsaw'), false];
+        yield [DateTime::fromString('2020-10-25 02:00:00 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-10-25 02:30:30 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-10-25 02:59:59 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-10-25 03:00:00 Europe/Warsaw')];
+    }
 
-        yield [DateTime::fromString('2020-03-29 01:59:58 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-03-29 01:59:59 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-03-29 02:00:00 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-03-29 02:59:59 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-03-29 03:00:00 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-03-29 03:01:00 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-03-29 04:00:00 Europe/Warsaw'), false];
-        yield [DateTime::fromString('2020-03-29 05:00:00 Europe/Warsaw'), false];
+    /**
+     * @dataProvider not_ambiguous_time_data_provider
+     */
+    public function test_checking_is_not_ambiguous(DateTime $dateTime) : void
+    {
+        $this->assertFalse($dateTime->isAmbiguous());
+    }
+
+    /**
+     * @return \Generator<int, array{DateTime}, mixed, void>
+     */
+    public function not_ambiguous_time_data_provider() : \Generator
+    {
+        yield [new DateTime(Day::fromString('2020-01-01'), Time::fromString('00:00:00'), TimeZone::UTC())];
+        yield [DateTime::fromString('2020-10-25 01:59:59 UTC')];
+        yield [DateTime::fromString('2020-10-25 00:00:00 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-10-25 01:00:00 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-10-25 01:59:59 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-10-25 03:01:00 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-03-29 01:59:58 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-03-29 01:59:59 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-03-29 02:00:00 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-03-29 02:59:59 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-03-29 03:00:00 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-03-29 03:01:00 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-03-29 04:00:00 Europe/Warsaw')];
+        yield [DateTime::fromString('2020-03-29 05:00:00 Europe/Warsaw')];
     }
 
     public function test_using_create_constructor_during_dst_gap() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>DateTime::isAmbiguous bug at PHP 8.1</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
