### PR TITLE
Add `isMidnight` and `isNotMidnight` utility methods to `Time`

### DIFF
--- a/src/Aeon/Calendar/Gregorian/Time.php
+++ b/src/Aeon/Calendar/Gregorian/Time.php
@@ -333,6 +333,19 @@ final class Time
         return $dateTimeImmutable <= $nextDateTimeImmutable;
     }
 
+    public function isMidnight() : bool
+    {
+        return $this->hour() === 0
+            && $this->minute() === 0
+            && $this->second() === 0
+            && $this->microsecond() === 0;
+    }
+
+    public function isNotMidnight() : bool
+    {
+        return !$this->isMidnight();
+    }
+
     public function add(TimeUnit $timeUnit) : self
     {
         return self::fromDateTime($this->toDateTimeImmutable()->add($timeUnit->toDateInterval()));

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
@@ -236,4 +236,26 @@ final class TimeTest extends TestCase
             $time
         );
     }
+
+    public function test_is_midnight() : void
+    {
+        $this->assertTrue(Time::fromString('00:00')->isMidnight());
+        $this->assertTrue(Time::fromString('00:00:00')->isMidnight());
+
+        $this->assertFalse(Time::fromString('15:00:00')->isMidnight());
+        $this->assertFalse(Time::fromString('15:27:00')->isMidnight());
+        $this->assertFalse(Time::fromString('15:27:28')->isMidnight());
+        $this->assertFalse(Time::fromString('15:27:28:000001')->isMidnight());
+    }
+
+    public function test_is_not_midnight() : void
+    {
+        $this->assertTrue(Time::fromString('15:00:00')->isNotMidnight());
+        $this->assertTrue(Time::fromString('15:27:00')->isNotMidnight());
+        $this->assertTrue(Time::fromString('15:27:28')->isNotMidnight());
+        $this->assertTrue(Time::fromString('15:27:28:000001')->isNotMidnight());
+
+        $this->assertFalse(Time::fromString('00:00')->isNotMidnight());
+        $this->assertFalse(Time::fromString('00:00:00')->isNotMidnight());
+    }
 }

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/TimeTest.php
@@ -245,7 +245,7 @@ final class TimeTest extends TestCase
         $this->assertFalse(Time::fromString('15:00:00')->isMidnight());
         $this->assertFalse(Time::fromString('15:27:00')->isMidnight());
         $this->assertFalse(Time::fromString('15:27:28')->isMidnight());
-        $this->assertFalse(Time::fromString('15:27:28:000001')->isMidnight());
+        $this->assertFalse(Time::fromString('15:27:28.000001')->isMidnight());
     }
 
     public function test_is_not_midnight() : void
@@ -253,7 +253,7 @@ final class TimeTest extends TestCase
         $this->assertTrue(Time::fromString('15:00:00')->isNotMidnight());
         $this->assertTrue(Time::fromString('15:27:00')->isNotMidnight());
         $this->assertTrue(Time::fromString('15:27:28')->isNotMidnight());
-        $this->assertTrue(Time::fromString('15:27:28:000001')->isNotMidnight());
+        $this->assertTrue(Time::fromString('15:27:28.000001')->isNotMidnight());
 
         $this->assertFalse(Time::fromString('00:00')->isNotMidnight());
         $this->assertFalse(Time::fromString('00:00:00')->isNotMidnight());


### PR DESCRIPTION
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added object oriented utility method <code>isMidnight</code> to <code>Time</code></li>
    <li>Added object oriented utility method <code>isNotMidnight</code> to <code>Time</code></li>
  </ul> 
</div>
<hr/>

<h2>Description</h2>

Added new object oriented utility methods to `Time` to prevent having to use external helpers that are less readable like `DateHelper::isTimeAtMidnight($this->timeTo)`.

This is the second version of the pull request with rebased fork.