### PR TITLE
Add magic `__toString` to `Month`

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -24,6 +24,6 @@ jobs:
       infection_badge_api_key: ${{ secrets.INFECTION_BADGE_API_KEY }}
       stryker_dashboard_api_key: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 
-  benchmark:
-    name: "Benchmark"
-    uses: aeon-php/actions/.github/workflows/composer-script-benchmark.yaml@main
+#  benchmark:
+#    name: "Benchmark"
+#    uses: aeon-php/actions/.github/workflows/composer-script-benchmark.yaml@main

--- a/benchmark/Aeon/Calendar/Benchmark/Gregorian/DateTimeFormatBench.php
+++ b/benchmark/Aeon/Calendar/Benchmark/Gregorian/DateTimeFormatBench.php
@@ -10,26 +10,27 @@ use Aeon\Calendar\Gregorian\DateTime;
  * @revs(50)
  * @iterations(10)
  * @outputTimeUnit("milliseconds")
+ * @BeforeMethods({"init"})
  */
-final class DateTimeBenchUnixTimestamp
+final class DateTimeFormatBench
 {
     private DateTime $aeonDateTime;
 
     private \DateTimeImmutable $dateTime;
 
-    public function __construct()
+    public function init() : void
     {
         $this->aeonDateTime = DateTime::fromString('2020-01-01 00:00:00');
         $this->dateTime = new \DateTimeImmutable('2020-01-01 00:00:00');
     }
 
-    public function bench_aeon_unix_timestamp() : void
+    public function bench_aeon_format() : void
     {
-        $this->aeonDateTime->timestampUNIX();
+        $this->aeonDateTime->format('Y-m-d H:i:s.u P');
     }
 
-    public function bench_php_unix_timestamp() : void
+    public function bench_php_format() : void
     {
-        $this->dateTime->getTimestamp();
+        $this->dateTime->format('Y-m-d H:i:s.u P');
     }
 }

--- a/benchmark/Aeon/Calendar/Benchmark/Gregorian/DateTimeUnixTimestampBench.php
+++ b/benchmark/Aeon/Calendar/Benchmark/Gregorian/DateTimeUnixTimestampBench.php
@@ -10,27 +10,26 @@ use Aeon\Calendar\Gregorian\DateTime;
  * @revs(50)
  * @iterations(10)
  * @outputTimeUnit("milliseconds")
- * @BeforeMethods({"init"})
  */
-final class DateTimeBenchFormat
+final class DateTimeUnixTimestampBench
 {
     private DateTime $aeonDateTime;
 
     private \DateTimeImmutable $dateTime;
 
-    public function init() : void
+    public function __construct()
     {
         $this->aeonDateTime = DateTime::fromString('2020-01-01 00:00:00');
         $this->dateTime = new \DateTimeImmutable('2020-01-01 00:00:00');
     }
 
-    public function bench_aeon_format() : void
+    public function bench_aeon_unix_timestamp() : void
     {
-        $this->aeonDateTime->format('Y-m-d H:i:s.u P');
+        $this->aeonDateTime->timestampUNIX();
     }
 
-    public function bench_php_format() : void
+    public function bench_php_unix_timestamp() : void
     {
-        $this->dateTime->format('Y-m-d H:i:s.u P');
+        $this->dateTime->getTimestamp();
     }
 }

--- a/src/Aeon/Calendar/Gregorian/Month.php
+++ b/src/Aeon/Calendar/Gregorian/Month.php
@@ -99,14 +99,14 @@ final class Month implements \Stringable
         $this->days = new MonthDays($this);
     }
 
-    public function toString() : string
-    {
-        return $this->toDateTimeImmutable()->format('Y-m');
-    }
-
     public function __toString() : string
     {
         return $this->toString();
+    }
+
+    public function toString() : string
+    {
+        return $this->toDateTimeImmutable()->format('Y-m');
     }
 
     public function previous() : self

--- a/src/Aeon/Calendar/Gregorian/Month.php
+++ b/src/Aeon/Calendar/Gregorian/Month.php
@@ -11,7 +11,7 @@ use Aeon\Calendar\TimeUnit;
 /**
  * @psalm-immutable
  */
-final class Month
+final class Month implements \Stringable
 {
     private const TOTAL_MONTHS = 12;
 
@@ -102,6 +102,11 @@ final class Month
     public function toString() : string
     {
         return $this->toDateTimeImmutable()->format('Y-m');
+    }
+
+    public function __toString() : string
+    {
+        return $this->toString();
     }
 
     public function previous() : self

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/MonthTest.php
@@ -134,6 +134,11 @@ final class MonthTest extends TestCase
             '2020-01',
             Month::fromString('2020-01-01')->toString()
         );
+
+        $this->assertSame(
+            '2020-01',
+            (string) Month::fromString('2020-01-01')
+        );
     }
 
     public function test_last_day_of_month() : void

--- a/tools/composer.json
+++ b/tools/composer.json
@@ -6,7 +6,7 @@
         "vimeo/psalm": "^4.6",
         "phpstan/phpstan": "^1.1.2",
         "infection/infection": "^0.26.1",
-        "phpbench/phpbench": "^1.0.0-alpha7",
+        "phpbench/phpbench": "^1.2.6",
         "friendsofphp/php-cs-fixer": "^3.1"
     },
     "config": {

--- a/tools/composer.lock
+++ b/tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05660902913ecd2576bd32e269e82f83",
+    "content-hash": "e12bc5e00291ac117b8740fa11e10b37",
     "packages": [],
     "packages-dev": [
         {
@@ -5714,9 +5714,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "phpbench/phpbench": 15
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],


### PR DESCRIPTION
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added magic <code>__toString()</code> method to <code>Month</code>.</li>
  </ul> 
</div>
<hr/>

<h2>Description</h2>

I'm using `Month` in Doctrine and added a custom `DoctrineType` for it (PR pending on the calendar-doctrine repository). When using a `Month` property as part of a composition key like the following ...

```php
class SettlementCacheLog
{
    #[ORM\Id]
    #[ORM\Column(name: 'farm_id', type: 'farm_id')]
    public FarmId $farmId;

    #[ORM\Id]
    #[ORM\Column(name: 'month', type: 'aeon_month')]
    public Month $month;
    ...
```

... the hydration will fail with ...

```
{type: "https://tools.ietf.org/html/rfc2616#section-10", title: "An error occurred", status: 500,…}
class: "Error"
detail: "Object of class Aeon\\Calendar\\Gregorian\\Month could not be converted to string"
status: 500
title: "An error occurred"
trace: [{namespace: "", short_class: "", class: "", type: "", function: "",…},…]
0: {namespace: "", short_class: "", class: "", type: "", function: "",…}
1: {namespace: "", short_class: "", class: "", type: "", function: "implode",…}
2: {namespace: "Doctrine\ORM", short_class: "UnitOfWork", class: "Doctrine\ORM\UnitOfWork", type: "->",…}
3: {namespace: "Doctrine\ORM\Internal\Hydration", short_class: "SimpleObjectHydrator",…}
4: {namespace: "Doctrine\ORM\Internal\Hydration", short_class: "SimpleObjectHydrator",…}
5: {namespace: "Doctrine\ORM\Internal\Hydration", short_class: "AbstractHydrator",…}
6: {namespace: "Doctrine\ORM\Persisters\Entity", short_class: "BasicEntityPersister",…}
...
```

... as long as there is no `__toString` method on the class.

This PR solves this issue. The method calls the internal `toString()` method so that there is no complexity overhead 🙂