### PR TITLE
Add native modify

### DIFF
--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -371,11 +371,14 @@ final class DateTime
 
     public function nativeModify(string $modifier) : self
     {
-        return self::fromDateTime(
-            $this
+        $modifiedDateTime = $this
             ->toDateTimeImmutable()
-            ->modify($modifier)
-        );
+            ->modify($modifier);
+        if ($modifiedDateTime === false) {
+            throw new \InvalidArgumentException("The modifier \"{$modifier}\" is not valid.");
+        }
+
+        return self::fromDateTime($modifiedDateTime);
     }
 
     public function addHour() : self

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -371,13 +371,18 @@ final class DateTime
 
     public function nativeModify(string $modifier) : self
     {
+        $dateTimeParts = \date_parse($modifier);
+
+        if ($dateTimeParts === false
+            || $dateTimeParts['error_count'] > 0
+        ) {
+            throw new \InvalidArgumentException("The modifier \"{$modifier}\" is not valid.");
+        }
+
+        /** @var \DateTimeImmutable $modifiedDateTime */
         $modifiedDateTime = $this
             ->toDateTimeImmutable()
             ->modify($modifier);
-
-        if ($modifiedDateTime === false) {
-            throw new \InvalidArgumentException("The modifier \"{$modifier}\" is not valid.");
-        }
 
         return self::fromDateTime($modifiedDateTime);
     }

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -371,6 +371,7 @@ final class DateTime
 
     public function nativeModify(string $modifier) : self
     {
+        /** @var array|false $dateTimeParts */
         $dateTimeParts = \date_parse($modifier);
 
         if ($dateTimeParts === false

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -371,7 +371,6 @@ final class DateTime
 
     public function nativeModify(string $modifier) : self
     {
-        /** @var array|false $dateTimeParts */
         $dateTimeParts = \date_parse($modifier);
 
         if ($dateTimeParts === false

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -369,6 +369,15 @@ final class DateTime
         );
     }
 
+    public function nativeModify(string $modifier) : self
+    {
+        return self::fromDateTime(
+            $this
+            ->toDateTimeImmutable()
+            ->modify($modifier)
+        );
+    }
+
     public function addHour() : self
     {
         return $this->add(TimeUnit::hour());

--- a/src/Aeon/Calendar/Gregorian/DateTime.php
+++ b/src/Aeon/Calendar/Gregorian/DateTime.php
@@ -374,6 +374,7 @@ final class DateTime
         $modifiedDateTime = $this
             ->toDateTimeImmutable()
             ->modify($modifier);
+
         if ($modifiedDateTime === false) {
             throw new \InvalidArgumentException("The modifier \"{$modifier}\" is not valid.");
         }

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -435,6 +435,14 @@ final class DateTimeTest extends TestCase
         $this->assertTrue($modifiedDate->isEqualTo($expectedDate));
     }
 
+    public function test_native_modify_with_invalid_modifier() : void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DateTime::fromString('2022-09-28 00:00:00')
+            ->nativeModify('invalid modifier');
+    }
+
     public function test_time() : void
     {
         $dateTime = DateTime::fromString('2020-01-01 12:54:23.001000');

--- a/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
+++ b/tests/Aeon/Calendar/Tests/Unit/Gregorian/DateTimeTest.php
@@ -421,6 +421,20 @@ final class DateTimeTest extends TestCase
         yield ['2022-10-25 15:00:00 UTC', 'previous Saturday', '2022-10-22 15:00:00 UTC'];
     }
 
+    // It switches back 14 days in a timezone aware manner
+    public function test_native_modify() : void
+    {
+        $nativeBaseDate = new \DateTimeImmutable(
+            '2023-04-01 00:00:00',
+            new \DateTimeZone('Europe/Berlin'),
+        );
+        $expectedDate = DateTime::fromDateTime($nativeBaseDate->modify('- 14 days'));
+
+        $modifiedDate = DateTime::fromDateTime($nativeBaseDate)->nativeModify('- 14 days');
+
+        $this->assertTrue($modifiedDate->isEqualTo($expectedDate));
+    }
+
     public function test_time() : void
     {
         $dateTime = DateTime::fromString('2020-01-01 12:54:23.001000');


### PR DESCRIPTION
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added native modify method</li>
  </ul> 
</div>
<hr/>

<h2>Description</h2>

I stumbled over the following issue:

In Germany there is a winter time to summer time switch on for example the 26. March 2023. When I work with modifications of a DateTime, the native DateTimeImmutable is aware of those switches. The current `modify` implementation internally uses seconds for all modifications and is able to solve issue like moving a month at the end of the month as we already touched upon here #294.

This means that when I'm using a DateTime and calling `modify` or `subDays` I get the result that at least differs from the expected date and might even be considered wrong.

For example:

```php
$firstOfApril = DateTime::fromDateTime(
    new \DateTimeImmutable(
        '2023-04-01 00:00:00',
        new \DateTimeZone('Europe/Berlin'),
    )
);

echo $firstOfApril->modify('- 14 days')->format(\DateTimeInterface::ATOM);
```

It results in

```
2023-03-17T23:00:00+01:00
```

If it would be timezone aware it would be

```
2023-03-18T00:00:00+01:00
```

I don't think this is something that can be "fixed" in the current `modify` as the internal approach with working with seconds kind of prevents a timezone aware logic.

Therefore, I introduced a new `nativeModify` method that simply pipes through the modifier to the internal `DateTimeImmutable`.